### PR TITLE
Resolve the issue with null GatewayConfig  

### DIFF
--- a/src/Validator/Constraints/PaymentMethodMollieChannelUniqueValidator.php
+++ b/src/Validator/Constraints/PaymentMethodMollieChannelUniqueValidator.php
@@ -123,8 +123,11 @@ final class PaymentMethodMollieChannelUniqueValidator extends ConstraintValidato
 
     private function isMolliePaymentMethod(PaymentMethodInterface $paymentMethod): bool
     {
-        /** @var GatewayConfigInterface $gateway */
+        /** @var GatewayConfigInterface|null $gateway */
         $gateway = $paymentMethod->getGatewayConfig();
+        if (null === $gateway) {
+            return false;
+        }
 
         return true === in_array(
             $gateway->getFactoryName(),


### PR DESCRIPTION
there are is an issue that changes default behaviour and fails sylius/sylius/features/checkout/paying_for_order/changing_offline_payment_method_after_order_confirmation.feature scenarios, as here we are assuming that gatewayconfig could not be null and it [throws 500](https://github.com/Sylius/Sylius-Standard/actions/runs/14444807760/job/40502792006?pr=1117#step:36:526) error on standard build.