### PR TITLE
Remove getName method from ProductVariant as it changes default behaviour of the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,11 +244,6 @@ class ProductVariant extends BaseProductVariant implements ProductVariantInterfa
     {
         return new ProductVariantTranslation();
     }
-
-    public function getName(): ?string
-    {
-        return parent::getName() ?: $this->getProduct()->getName();
-    }
 }
 
 ```

--- a/doc/legacy_installation.md
+++ b/doc/legacy_installation.md
@@ -181,11 +181,6 @@ class ProductVariant extends BaseProductVariant implements ProductVariantInterfa
     {
         return new ProductVariantTranslation();
     }
-
-    public function getName(): ?string
-    {
-        return parent::getName() ?: $this->getProduct()->getName();
-    }
 }
 
 ```


### PR DESCRIPTION
causes build fails and breaks how the variants are displayed while variant selection method is enabled on the product.

with this method:
![image (1)](https://github.com/user-attachments/assets/433a9b22-51a0-4bb0-9806-dcbf71e21df8)

without:
![image](https://github.com/user-attachments/assets/79b9754c-5f0c-4aa1-b2ea-138b01242d81)
