### PR TITLE
Typo in admin product form path

### DIFF
--- a/config/ui/admin/product.yaml
+++ b/config/ui/admin/product.yaml
@@ -3,10 +3,10 @@ sylius_ui:
         sylius.admin.product.create.tab_details:
             blocks:
                 mollie_product_type:
-                    template: '@SyliusMolliePlugin/Admin/Product/form/_productType.html.twig'
+                    template: '@SyliusMolliePlugin/Admin/Product/Form/_productType.html.twig'
                     priority: 10
         sylius.admin.product.update.tab_details:
             blocks:
                 mollie_product_type:
-                    template: '@SyliusMolliePlugin/Admin/Product/form/_productType.html.twig'
+                    template: '@SyliusMolliePlugin/Admin/Product/Form/_productType.html.twig'
                     priority: 10


### PR DESCRIPTION
On version 2.2 I get this error, which indicates that there's a typo in the path :
`request.CRITICAL: Uncaught PHP Exception Twig\Error\LoaderError: "Unable to find template "@SyliusMolliePlugin/Admin/Product/form/_productType.html.twig"` 
