### PR TITLE
Add telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,3 +458,8 @@ Instead, all security issues must be sent to `security@sylius.com`
 ## Community
 
 For online communication, we invite you to chat with us & other users on [Sylius Slack](https://sylius-devs.slack.com/).
+
+## Telemetry
+
+This plugin enforces telemetry data collection when used with Sylius.
+Details are described in [TELEMETRY_POLICY.md](./TELEMETRY_POLICY.md).

--- a/TELEMETRY_POLICY.md
+++ b/TELEMETRY_POLICY.md
@@ -1,0 +1,69 @@
+# Telemetry Policy
+
+## Applicability
+
+This Telemetry Policy applies to the use of this plugin in combination with Sylius.
+
+By installing or using this plugin with Sylius, the user acknowledges that telemetry data is collected and transmitted as described in this document.
+
+---
+
+## Mandatory telemetry
+
+Telemetry data collection is mandatory when this plugin is used.
+
+While this plugin is installed and active, Sylius telemetry operates under the conditions defined by this plugin and cannot be disabled independently.
+Telemetry behavior outside of this scope follows the standard Sylius configuration.
+
+---
+
+## Scope of collected data
+
+Telemetry is limited to non-identifying technical data, which may include:
+
+- Sylius version
+- plugin version
+- PHP version and selected dependency versions
+- identifiers of installed and enabled plugins
+- runtime environment classification (production or non-production)
+
+Telemetry does not include, and is not intended to include:
+
+- personal data
+- customer data
+- order data
+- product data
+- business, transactional, or confidential information
+- authentication credentials or secrets
+
+A detailed description of the Sylius telemetry mechanism is available in the public issue:
+https://github.com/Sylius/Sylius/issues/18588
+
+---
+
+## Purpose and use of telemetry data
+
+Telemetry data is collected for the purpose of:
+
+- understanding usage patterns within the Sylius ecosystem
+- analyzing the adoption and frequency of plugin usage
+- identifying commonly used versions of Sylius and plugins
+- supporting maintenance, compatibility, and future development efforts
+
+Telemetry data is processed in aggregated form and is not used to identify individual users, installations, or businesses.
+
+---
+
+## Licensing
+
+This plugin is distributed under the MIT license.
+
+Telemetry collection constitutes part of the technical operation of the software and does not alter, restrict, or supplement the rights granted under the license.
+
+---
+
+## Changes to this policy
+
+This Telemetry Policy may be updated to reflect changes in telemetry implementation, legal requirements, or operational practices.
+
+Updated versions of this policy will be made available in the plugin repository.

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "php-http/message-factory": "^1.1",
         "sylius/refund-plugin": "^1.5",
         "sylius/sylius": "^1.13",
+        "sylius/telemetry": "^1.0",
         "symfony/mailer": "^5.4 || ^6.4",
         "symfony/messenger": "^5.4 || ^6.4",
         "willdurand/js-translation-bundle": "^4.0 || ^5.0"
@@ -66,11 +67,16 @@
     "autoload": {
         "psr-4": {
             "Sylius\\MolliePlugin\\": "src/",
-            "Tests\\Sylius\\MolliePlugin\\": ["tests/", "tests/Application/src"]
+            "Tests\\Sylius\\MolliePlugin\\": [
+                "tests/",
+                "tests/Application/src"
+            ]
         }
     },
     "autoload-dev": {
-        "classmap": ["tests/Application/Kernel.php"]
+        "classmap": [
+            "tests/Application/Kernel.php"
+        ]
     },
     "config": {
         "allow-plugins": {

--- a/src/SyliusMolliePlugin.php
+++ b/src/SyliusMolliePlugin.php
@@ -16,6 +16,7 @@ namespace Sylius\MolliePlugin;
 use Sylius\Bundle\CoreBundle\Application\SyliusPluginTrait;
 use Sylius\MolliePlugin\DependencyInjection\AdminOrderCreationCompatibilityPass;
 use Sylius\MolliePlugin\DependencyInjection\SyliusMessageBusPolyfillPass;
+use Sylius\Telemetry\TelemetryCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -33,6 +34,7 @@ final class SyliusMolliePlugin extends Bundle
 
         $container->addCompilerPass(new SyliusMessageBusPolyfillPass());
         $container->addCompilerPass(new AdminOrderCreationCompatibilityPass());
+        $container->addCompilerPass(new TelemetryCompilerPass());
     }
 
     public function getPath(): string


### PR DESCRIPTION
Adds telemetry policy and `sylius/telemetry-bundle` as a hard dependency.

- `TELEMETRY_POLICY.md` — describes scope, purpose, and conditions of telemetry data collection
- `composer.json` — requires `sylius/telemetry-bundle: ^1.0`
- `README.md` — telemetry notice pointing to the policy file

Related: https://github.com/Sylius/Sylius/issues/18588