### PR TITLE
[API] Improve checkout/payments handling

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -8,6 +8,10 @@ sylius_mollie_shop:
     requirements:
         _locale: ^[A-Za-z]{2,4}(_([A-Za-z]{4}|[0-9]{3}))?(_([A-Za-z]{2}|[0-9]{3}))?$
 
+sylius_mollie_api_shop:
+    prefix: "/%sylius.security.api_shop_route%"
+    resource: "routes/api_shop.yaml"
+
 mollie_refund_integration:
     resource: "integration/refund-plugin/routes.php"
     prefix: /%sylius_admin.path_name%

--- a/config/routes/api_shop.yaml
+++ b/config/routes/api_shop.yaml
@@ -9,3 +9,9 @@ sylius_mollie_api_shop_order_mollie_select_method:
     methods: ['POST']
     defaults:
         _controller: sylius_mollie.api.controller.select_mollie_method
+
+sylius_mollie_api_shop_order_mollie_payment_status:
+    path: orders/{tokenValue}/mollie-status
+    methods: ['GET']
+    defaults:
+        _controller: sylius_mollie.api.controller.get_mollie_status

--- a/config/routes/api_shop.yaml
+++ b/config/routes/api_shop.yaml
@@ -3,3 +3,9 @@ sylius_mollie_api_shop_order_mollie_methods:
     methods: ['GET']
     defaults:
         _controller: sylius_mollie.api.controller.get_mollie_methods
+
+sylius_mollie_api_shop_order_mollie_select_method:
+    path: orders/{tokenValue}/mollie-methods
+    methods: ['POST']
+    defaults:
+        _controller: sylius_mollie.api.controller.select_mollie_method

--- a/config/routes/api_shop.yaml
+++ b/config/routes/api_shop.yaml
@@ -1,0 +1,5 @@
+sylius_mollie_api_shop_order_mollie_methods:
+    path: orders/{tokenValue}/mollie-methods
+    methods: ['GET']
+    defaults:
+        _controller: sylius_mollie.api.controller.get_mollie_methods

--- a/config/services.xml
+++ b/config/services.xml
@@ -23,15 +23,6 @@
     </imports>
 
     <services>
-        <service
-            id="sylius_mollie.api.payment_configuration_provider.mollie"
-            class="Sylius\MolliePlugin\Api\MolliePaymentConfigurationProvider"
-        >
-            <argument type="service" id="router" />
-
-            <tag name="sylius.api.payment_method_handler" />
-        </service>
-
         <service id="sylius_mollie.refund.guard.mollie_payment_refund" class="Sylius\MolliePlugin\Refund\Guard\PaymentRefundGuard" public="true" >
             <argument>%kernel.bundles%</argument>
         </service>

--- a/config/services/api.xml
+++ b/config/services/api.xml
@@ -27,7 +27,7 @@
         </service>
 
         <service id="sylius_mollie.api.controller.get_mollie_methods" class="Sylius\MolliePlugin\Api\Controller\GetMollieMethodsAction" public="true">
-            <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="sylius_mollie.repository.query.order.by_token_for_available_methods" />
             <argument type="service" id="sylius_mollie.payum.checker.mollie_gateway_factory" />
             <argument type="service" id="sylius_mollie.resolver.payment_methods" />
             <argument type="service" id="liip_imagine.cache.manager" />

--- a/config/services/api.xml
+++ b/config/services/api.xml
@@ -32,5 +32,23 @@
             <argument type="service" id="sylius_mollie.resolver.payment_methods" />
             <argument type="service" id="liip_imagine.cache.manager" />
         </service>
+
+        <service id="sylius_mollie.api.controller.select_mollie_method" class="Sylius\MolliePlugin\Api\Controller\SelectMollieMethodAction" public="true">
+            <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="doctrine.orm.entity_manager" />
+            <argument type="service" id="sylius_mollie.converter.int_to_string" />
+            <argument type="service" id="router" />
+            <argument type="service" id="sylius_mollie.resolver.mollie_api_client_key" />
+            <argument type="service" id="sylius_mollie.payum.checker.mollie_gateway_factory" />
+            <argument type="service" id="sylius_mollie.provider.payment_description" />
+            <argument type="service" id="sylius_mollie.resolver.payment_locale" />
+            <argument type="service" id="sylius_mollie.provider.divisor" />
+            <argument type="service" id="sylius_mollie.repository.mollie_gateway_config" />
+            <argument type="service" id="sylius_mollie.repository.mollie_customer" />
+            <argument type="service" id="sylius_mollie.custom_factory.mollie_subscription" />
+            <argument type="service" id="sylius_mollie.repository.mollie_subscription" />
+            <argument type="service" id="sylius_mollie.logger.mollie_logger_action" />
+            <argument type="service" id="sylius_mollie.converter.order" />
+        </service>
     </services>
 </container>

--- a/config/services/api.xml
+++ b/config/services/api.xml
@@ -50,5 +50,13 @@
             <argument type="service" id="sylius_mollie.logger.mollie_logger_action" />
             <argument type="service" id="sylius_mollie.converter.order" />
         </service>
+
+        <service id="sylius_mollie.api.controller.get_mollie_status" class="Sylius\MolliePlugin\Api\Controller\GetMollieStatusAction" public="true">
+            <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="doctrine.orm.entity_manager" />
+            <argument type="service" id="sylius_mollie.resolver.mollie_api_client_key" />
+            <argument type="service" id="sylius_abstraction.state_machine" />
+            <argument type="service" id="sylius_mollie.logger.mollie_logger_action" />
+        </service>
     </services>
 </container>

--- a/config/services/api.xml
+++ b/config/services/api.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<!--
+
+ This file is part of the Sylius Mollie Plugin package.
+
+ (c) Sylius Sp. z o.o.
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container
+    xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <services>
+        <service
+            id="sylius_mollie.api.payment_configuration_provider.mollie"
+            class="Sylius\MolliePlugin\Api\MolliePaymentConfigurationProvider"
+        >
+            <argument type="service" id="router" />
+
+            <tag name="sylius.api.payment_method_handler" />
+        </service>
+
+        <service id="sylius_mollie.api.controller.get_mollie_methods" class="Sylius\MolliePlugin\Api\Controller\GetMollieMethodsAction" public="true">
+            <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="sylius_mollie.payum.checker.mollie_gateway_factory" />
+            <argument type="service" id="sylius_mollie.resolver.payment_methods" />
+            <argument type="service" id="liip_imagine.cache.manager" />
+        </service>
+    </services>
+</container>

--- a/config/services/api.xml
+++ b/config/services/api.xml
@@ -58,5 +58,11 @@
             <argument type="service" id="sylius_abstraction.state_machine" />
             <argument type="service" id="sylius_mollie.logger.mollie_logger_action" />
         </service>
+
+        <service id="sylius_mollie.api.open_api.mollie_documentation_modifier" class="Sylius\MolliePlugin\Api\OpenApi\MollieDocumentationModifier">
+            <argument>%sylius.security.api_shop_route%</argument>
+
+            <tag name="sylius.open_api.modifier" />
+        </service>
     </services>
 </container>

--- a/config/services/controller/shop.xml
+++ b/config/services/controller/shop.xml
@@ -63,6 +63,7 @@
             <argument type="service" id="sylius_mollie.resolver.mollie_api_client_key"/>
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius.repository.payment" />
+            <argument type="service" id="sylius_mollie.logger.mollie_logger_action" />
         </service>
 
         <service id="sylius_mollie.controller.shop.page_redirect" class="Sylius\MolliePlugin\Controller\Shop\PageRedirectController">

--- a/config/services/repository.xml
+++ b/config/services/repository.xml
@@ -26,5 +26,10 @@
             <argument type="service" id="sylius.repository.payment_method" />
         </service>
         <service id="Sylius\MolliePlugin\Repository\Query\MollieBasedPaymentMethodQueryInterface" alias="sylius_mollie.repository.query.payment_method.mollie_based" />
+
+        <service id="sylius_mollie.repository.query.order.by_token_for_available_methods" class="Sylius\MolliePlugin\Repository\Query\OrderByTokenForAvailableMethodsQuery">
+            <argument type="service" id="sylius.repository.order" />
+        </service>
+        <service id="Sylius\MolliePlugin\Repository\Query\OrderByTokenForAvailableMethodsQueryInterface" alias="sylius_mollie.repository.query.order.by_token_for_available_methods" />
     </services>
 </container>

--- a/src/Api/Controller/GetMollieMethodsAction.php
+++ b/src/Api/Controller/GetMollieMethodsAction.php
@@ -1,15 +1,24 @@
 <?php
 
+/*
+ * This file is part of the Sylius Mollie Plugin package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\MolliePlugin\Api\Controller;
 
-use Sylius\Component\Core\Model\OrderInterface;
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Sylius\MolliePlugin\Entity\GatewayConfigInterface;
+use Sylius\MolliePlugin\Entity\OrderInterface;
 use Sylius\MolliePlugin\Entity\PaymentSurchargeFeeInterface;
 use Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface;
 use Sylius\MolliePlugin\Resolver\MolliePaymentsMethodResolver;
@@ -54,9 +63,9 @@ final class GetMollieMethodsAction
 
         $availableMethods = $this->molliePaymentsMethodResolver->resolve();
 
-        $data = $availableMethods['data'] ?? [];
-        $images = $availableMethods['image'] ?? [];
-        $paymentFees = $availableMethods['paymentFee'] ?? [];
+        $data = $availableMethods['data'];
+        $images = $availableMethods['image'];
+        $paymentFees = $availableMethods['paymentFee'];
         $result = [];
         foreach ($data as $id => $label) {
             $result[] = [
@@ -70,15 +79,14 @@ final class GetMollieMethodsAction
         return new JsonResponse($result);
     }
 
-    private function normalizeImage(?string $image): ?string
-    {
-        if (null === $image || str_starts_with($image, 'https://') && str_contains($image, 'mollie.com')) {
-            return $image;
-        }
-
-        return $this->imagineCacheManager->getBrowserPath($image, 'sylius_original');
-    }
-
+    /**
+     * @return array{
+     *     type: string|null,
+     *     fixedAmount: float|null,
+     *     percentage: float|null,
+     *     surchargeLimit: float|null,
+     *  }|null
+     */
     private function normalizePaymentFee(mixed $fee): ?array
     {
         if ($fee instanceof PaymentSurchargeFeeInterface) {
@@ -91,5 +99,14 @@ final class GetMollieMethodsAction
         }
 
         return null;
+    }
+
+    private function normalizeImage(?string $image): ?string
+    {
+        if (null === $image || str_starts_with($image, 'https://') && str_contains($image, 'mollie.com')) {
+            return $image;
+        }
+
+        return $this->imagineCacheManager->getBrowserPath($image, 'sylius_original');
     }
 }

--- a/src/Api/Controller/GetMollieMethodsAction.php
+++ b/src/Api/Controller/GetMollieMethodsAction.php
@@ -27,6 +27,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 final class GetMollieMethodsAction
 {
+    use PayableOrderTrait;
+
     public function __construct(
         private readonly OrderByTokenForAvailableMethodsQueryInterface $orderByTokenForAvailableMethodsQuery,
         private readonly MollieGatewayFactoryCheckerInterface $mollieGatewayFactoryChecker,
@@ -41,6 +43,8 @@ final class GetMollieMethodsAction
         if (null === $order) {
             throw new NotFoundHttpException(sprintf('Order with token "%s" not found', $tokenValue));
         }
+
+        $this->assertOrderIsPayable($order);
 
         $payment = $order->getLastPayment();
         if (!$payment instanceof PaymentInterface) {

--- a/src/Api/Controller/GetMollieMethodsAction.php
+++ b/src/Api/Controller/GetMollieMethodsAction.php
@@ -16,11 +16,10 @@ namespace Sylius\MolliePlugin\Api\Controller;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
-use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\MolliePlugin\Entity\GatewayConfigInterface;
-use Sylius\MolliePlugin\Entity\OrderInterface;
 use Sylius\MolliePlugin\Entity\PaymentSurchargeFeeInterface;
 use Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface;
+use Sylius\MolliePlugin\Repository\Query\OrderByTokenForAvailableMethodsQueryInterface;
 use Sylius\MolliePlugin\Resolver\MolliePaymentsMethodResolver;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -29,7 +28,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 final class GetMollieMethodsAction
 {
     public function __construct(
-        private readonly OrderRepositoryInterface $orderRepository,
+        private readonly OrderByTokenForAvailableMethodsQueryInterface $orderByTokenForAvailableMethodsQuery,
         private readonly MollieGatewayFactoryCheckerInterface $mollieGatewayFactoryChecker,
         private readonly MolliePaymentsMethodResolver $molliePaymentsMethodResolver,
         private readonly CacheManager $imagineCacheManager,
@@ -38,8 +37,8 @@ final class GetMollieMethodsAction
 
     public function __invoke(string $tokenValue): JsonResponse
     {
-        $order = $this->orderRepository->findOneByTokenValue($tokenValue);
-        if (!$order instanceof OrderInterface) {
+        $order = $this->orderByTokenForAvailableMethodsQuery->getOrder($tokenValue);
+        if (null === $order) {
             throw new NotFoundHttpException(sprintf('Order with token "%s" not found', $tokenValue));
         }
 

--- a/src/Api/Controller/GetMollieMethodsAction.php
+++ b/src/Api/Controller/GetMollieMethodsAction.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\MolliePlugin\Api\Controller;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Sylius\MolliePlugin\Entity\GatewayConfigInterface;
+use Sylius\MolliePlugin\Entity\PaymentSurchargeFeeInterface;
+use Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface;
+use Sylius\MolliePlugin\Resolver\MolliePaymentsMethodResolver;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class GetMollieMethodsAction
+{
+    public function __construct(
+        private readonly OrderRepositoryInterface $orderRepository,
+        private readonly MollieGatewayFactoryCheckerInterface $mollieGatewayFactoryChecker,
+        private readonly MolliePaymentsMethodResolver $molliePaymentsMethodResolver,
+        private readonly CacheManager $imagineCacheManager,
+    ) {
+    }
+
+    public function __invoke(string $tokenValue): JsonResponse
+    {
+        $order = $this->orderRepository->findOneByTokenValue($tokenValue);
+        if (!$order instanceof OrderInterface) {
+            throw new NotFoundHttpException(sprintf('Order with token "%s" not found', $tokenValue));
+        }
+
+        $payment = $order->getLastPayment();
+        if (!$payment instanceof PaymentInterface) {
+            throw new NotFoundHttpException('No payment found');
+        }
+
+        $paymentMethod = $payment->getMethod();
+        if (!$paymentMethod instanceof PaymentMethodInterface) {
+            throw new NotFoundHttpException('No payment method found');
+        }
+
+        $gatewayConfig = $paymentMethod->getGatewayConfig();
+        if (!$gatewayConfig instanceof GatewayConfigInterface) {
+            throw new NotFoundHttpException('No gateway config found');
+        }
+        if (!$this->mollieGatewayFactoryChecker->isMollieGateway($gatewayConfig)) {
+            throw new BadRequestException('The payment method is not using Mollie');
+        }
+
+        $availableMethods = $this->molliePaymentsMethodResolver->resolve();
+
+        $data = $availableMethods['data'] ?? [];
+        $images = $availableMethods['image'] ?? [];
+        $paymentFees = $availableMethods['paymentFee'] ?? [];
+        $result = [];
+        foreach ($data as $id => $label) {
+            $result[] = [
+                'id' => $id,
+                'label' => $label,
+                'image' => $this->normalizeImage($images[$id] ?? null),
+                'paymentFee' => $this->normalizePaymentFee($paymentFees[$id] ?? null),
+            ];
+        }
+
+        return new JsonResponse($result);
+    }
+
+    private function normalizeImage(?string $image): ?string
+    {
+        if (null === $image || str_starts_with($image, 'https://') && str_contains($image, 'mollie.com')) {
+            return $image;
+        }
+
+        return $this->imagineCacheManager->getBrowserPath($image, 'sylius_original');
+    }
+
+    private function normalizePaymentFee(mixed $fee): ?array
+    {
+        if ($fee instanceof PaymentSurchargeFeeInterface) {
+            return [
+                'type' => $fee->getType(),
+                'fixedAmount' => $fee->getFixedAmount(),
+                'percentage' => $fee->getPercentage(),
+                'surchargeLimit' => $fee->getSurchargeLimit(),
+            ];
+        }
+
+        return null;
+    }
+}

--- a/src/Api/Controller/GetMollieStatusAction.php
+++ b/src/Api/Controller/GetMollieStatusAction.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\MolliePlugin\Api\Controller;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Mollie\Api\Types\PaymentStatus as MolliePaymentStatus;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Payment\PaymentTransitions;
+use Sylius\MolliePlugin\Logger\MollieLoggerActionInterface;
+use Sylius\MolliePlugin\Resolver\MollieApiClientKeyResolverInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class GetMollieStatusAction
+{
+    public function __construct(
+        private readonly OrderRepositoryInterface $orderRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MollieApiClientKeyResolverInterface $apiKeyResolver,
+        private readonly StateMachineInterface $stateMachine,
+        private readonly MollieLoggerActionInterface $logger,
+    ) {
+    }
+
+    public function __invoke(string $tokenValue): JsonResponse
+    {
+        $order = $this->orderRepository->findOneByTokenValue($tokenValue);
+        if (null === $order) {
+            throw new NotFoundHttpException(sprintf('Order with token "%s" not found', $tokenValue));
+        }
+
+        $payment = $order->getLastPayment();
+        if (null === $payment) {
+            throw new NotFoundHttpException('No payment found for this order');
+        }
+
+        $details = $payment->getDetails();
+        $molliePaymentId = $details['payment_mollie_id'] ?? null;
+        if (null === $molliePaymentId) {
+            $this->logger->addNegativeLog(sprintf(
+                'No Mollie payment ID found in payment details of order with token: %s',
+                $tokenValue,
+            ));
+
+            throw new NotFoundHttpException('No payment found for this order');
+        }
+
+        try {
+            $mollieApiClient = $this->apiKeyResolver->getClientWithKey($order);
+            $molliePayment = $mollieApiClient->payments->get($molliePaymentId);
+            $mollieStatus = $molliePayment->status;
+        } catch (\Exception $exception) {
+            $this->logger->addNegativeLog(sprintf('Error fetching Mollie payment status: %s', $exception->getMessage()));
+
+            return new JsonResponse([
+                'error' => 'Could not retrieve Mollie payment status',
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        $transition = $this->mapMolliePaymentStatusToTransition($mollieStatus);
+
+        if (null !== $transition && $this->stateMachine->can($payment, PaymentTransitions::GRAPH, $transition)) {
+            $this->stateMachine->apply($payment, PaymentTransitions::GRAPH, $transition);
+            $this->entityManager->flush();
+        }
+
+        return new JsonResponse([
+            'orderNumber' => $order->getNumber(),
+            'orderToken' => $tokenValue,
+            'paymentState' => $payment->getState(),
+        ]);
+    }
+
+    private function mapMolliePaymentStatusToTransition(string $status): ?string
+    {
+        return match ($status) {
+            MolliePaymentStatus::STATUS_PENDING, MolliePaymentStatus::STATUS_OPEN => PaymentTransitions::TRANSITION_PROCESS,
+            MolliePaymentStatus::STATUS_AUTHORIZED => PaymentTransitions::TRANSITION_AUTHORIZE,
+            MolliePaymentStatus::STATUS_PAID => PaymentTransitions::TRANSITION_COMPLETE,
+            MolliePaymentStatus::STATUS_CANCELED => PaymentTransitions::TRANSITION_CANCEL,
+            MolliePaymentStatus::STATUS_EXPIRED, MolliePaymentStatus::STATUS_FAILED => PaymentTransitions::TRANSITION_FAIL,
+            default => null,
+        };
+    }
+}

--- a/src/Api/Controller/GetMollieStatusAction.php
+++ b/src/Api/Controller/GetMollieStatusAction.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius Mollie Plugin package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\MolliePlugin\Api\Controller;
@@ -9,6 +18,7 @@ use Mollie\Api\Types\PaymentStatus as MolliePaymentStatus;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Payment\PaymentTransitions;
+use Sylius\MolliePlugin\Entity\OrderInterface;
 use Sylius\MolliePlugin\Logger\MollieLoggerActionInterface;
 use Sylius\MolliePlugin\Resolver\MollieApiClientKeyResolverInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -29,7 +39,7 @@ final class GetMollieStatusAction
     public function __invoke(string $tokenValue): JsonResponse
     {
         $order = $this->orderRepository->findOneByTokenValue($tokenValue);
-        if (null === $order) {
+        if (!$order instanceof OrderInterface) {
             throw new NotFoundHttpException(sprintf('Order with token "%s" not found', $tokenValue));
         }
 

--- a/src/Api/Controller/GetMollieStatusAction.php
+++ b/src/Api/Controller/GetMollieStatusAction.php
@@ -79,7 +79,6 @@ final class GetMollieStatusAction
         }
 
         return new JsonResponse([
-            'orderToken' => $tokenValue,
             'paymentState' => $payment->getState(),
         ]);
     }

--- a/src/Api/Controller/GetMollieStatusAction.php
+++ b/src/Api/Controller/GetMollieStatusAction.php
@@ -79,7 +79,6 @@ final class GetMollieStatusAction
         }
 
         return new JsonResponse([
-            'orderNumber' => $order->getNumber(),
             'orderToken' => $tokenValue,
             'paymentState' => $payment->getState(),
         ]);

--- a/src/Api/Controller/PayableOrderTrait.php
+++ b/src/Api/Controller/PayableOrderTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\MolliePlugin\Api\Controller;
+
+use Sylius\Component\Core\OrderPaymentStates;
+use Sylius\MolliePlugin\Entity\OrderInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+trait PayableOrderTrait
+{
+    protected function assertOrderIsPayable(OrderInterface $order): void
+    {
+        if (in_array($order->getPaymentState(), [
+            OrderPaymentStates::STATE_PAID,
+            OrderPaymentStates::STATE_CANCELLED,
+            OrderPaymentStates::STATE_REFUNDED,
+        ], true)) {
+            throw new BadRequestHttpException(sprintf('Order with token "%s" cannot be paid.', $order->getTokenValue()));
+        }
+    }
+}

--- a/src/Api/Controller/PayableOrderTrait.php
+++ b/src/Api/Controller/PayableOrderTrait.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius Mollie Plugin package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\MolliePlugin\Api\Controller;

--- a/src/Api/Controller/SelectMollieMethodAction.php
+++ b/src/Api/Controller/SelectMollieMethodAction.php
@@ -15,6 +15,7 @@ namespace Sylius\MolliePlugin\Api\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\Types\PaymentStatus;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
@@ -46,6 +47,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final class SelectMollieMethodAction
 {
+    use PayableOrderTrait;
+
     public function __construct(
         private readonly OrderRepositoryInterface $orderRepository,
         private readonly EntityManagerInterface $entityManager,
@@ -71,6 +74,8 @@ final class SelectMollieMethodAction
         if (!$order instanceof OrderInterface) {
             throw new NotFoundHttpException(sprintf('Order with token "%s" not found', $tokenValue));
         }
+
+        $this->assertOrderIsPayable($order);
 
         $data = json_decode($request->getContent(), true);
 
@@ -100,6 +105,11 @@ final class SelectMollieMethodAction
         }
 
         $mollieApiClient = $this->apiClientKeyResolver->getClientWithKey($order);
+
+        $existingPaymentResponse = $this->handleExistingMolliePayment($mollieApiClient, $payment, $methodId);
+        if (null !== $existingPaymentResponse) {
+            return $existingPaymentResponse;
+        }
 
         $customerMollieId = null;
         $isSubscription = $gatewayConfig->getFactoryName() === MollieSubscriptionGatewayFactory::FACTORY_NAME;
@@ -244,6 +254,46 @@ final class SelectMollieMethodAction
         }
 
         return $paymentData;
+    }
+
+    private function handleExistingMolliePayment(
+        MollieApiClient $mollieApiClient,
+        PaymentInterface $payment,
+        string $methodId,
+    ): ?JsonResponse {
+        $details = $payment->getDetails();
+        $existingMolliePaymentId = $details['payment_mollie_id'] ?? null;
+
+        if ($existingMolliePaymentId === null) {
+            return null;
+        }
+
+        try {
+            $existingMolliePayment = $mollieApiClient->payments->get($existingMolliePaymentId);
+        } catch (ApiException) {
+            return null;
+        }
+
+        if (!in_array(
+            $existingMolliePayment->status,
+            [PaymentStatus::STATUS_OPEN, PaymentStatus::STATUS_PENDING],
+            true,
+        )) {
+            return null;
+        }
+
+        $checkoutUrl = $existingMolliePayment->_links->checkout->href ?? null;
+        if (
+            null === $checkoutUrl ||
+            $methodId !== $existingMolliePayment->method
+        ) {
+            return null;
+        }
+
+        return new JsonResponse([
+            'methodId' => $methodId,
+            'checkoutUrl' => $checkoutUrl,
+        ]);
     }
 
     private function findOrCreateMollieCustomer(MollieApiClient $mollieApiClient, OrderInterface $order): string

--- a/src/Api/Controller/SelectMollieMethodAction.php
+++ b/src/Api/Controller/SelectMollieMethodAction.php
@@ -76,7 +76,7 @@ final class SelectMollieMethodAction
 
         $methodId = $data['methodId'] ?? null;
         $backUrl = $data['backUrl'] ?? null;
-        if (!$methodId || !$backUrl) {
+        if (empty($methodId) || empty($backUrl)) {
             throw new BadRequestHttpException('The `methodId` and `backUrl` are required');
         }
 
@@ -159,7 +159,7 @@ final class SelectMollieMethodAction
 
         $payment->setDetails($details);
 
-        if ($isSubscription && $order instanceof MollieOrderInterface) {
+        if ($isSubscription) {
             $this->createInternalSubscriptions($order, $paymentData, $customerMollieId);
         }
 

--- a/src/Api/Controller/SelectMollieMethodAction.php
+++ b/src/Api/Controller/SelectMollieMethodAction.php
@@ -1,12 +1,20 @@
 <?php
 
+/*
+ * This file is part of the Sylius Mollie Plugin package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\MolliePlugin\Api\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Mollie\Api\Exceptions\ApiException;
-use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
@@ -16,6 +24,7 @@ use Sylius\MolliePlugin\Converter\IntToStringConverterInterface;
 use Sylius\MolliePlugin\Converter\OrderConverterInterface;
 use Sylius\MolliePlugin\Entity\GatewayConfigInterface;
 use Sylius\MolliePlugin\Entity\MollieCustomer;
+use Sylius\MolliePlugin\Entity\OrderInterface;
 use Sylius\MolliePlugin\Entity\OrderInterface as MollieOrderInterface;
 use Sylius\MolliePlugin\Factory\MollieSubscriptionFactoryInterface;
 use Sylius\MolliePlugin\Logger\MollieLoggerActionInterface;
@@ -59,7 +68,6 @@ final class SelectMollieMethodAction
     public function __invoke(string $tokenValue, Request $request): JsonResponse
     {
         $order = $this->orderRepository->findOneByTokenValue($tokenValue);
-
         if (!$order instanceof OrderInterface) {
             throw new NotFoundHttpException(sprintf('Order with token "%s" not found', $tokenValue));
         }
@@ -163,6 +171,9 @@ final class SelectMollieMethodAction
         ]);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function createPaymentData(
         OrderInterface $order,
         PaymentInterface $payment,
@@ -263,6 +274,9 @@ final class SelectMollieMethodAction
         return $customer->getProfileId();
     }
 
+    /**
+     * @param array<string, mixed> $paymentData
+     */
     private function createInternalSubscriptions(
         MollieOrderInterface $order,
         array $paymentData,

--- a/src/Api/Controller/SelectMollieMethodAction.php
+++ b/src/Api/Controller/SelectMollieMethodAction.php
@@ -164,10 +164,8 @@ final class SelectMollieMethodAction
         $this->entityManager->flush();
 
         return new JsonResponse([
-            'success' => true,
             'methodId' => $methodId,
             'checkoutUrl' => $checkoutUrl,
-            'paymentId' => $molliePayment->id,
         ]);
     }
 

--- a/src/Api/Controller/SelectMollieMethodAction.php
+++ b/src/Api/Controller/SelectMollieMethodAction.php
@@ -73,10 +73,11 @@ final class SelectMollieMethodAction
         }
 
         $data = json_decode($request->getContent(), true);
-        $methodId = $data['methodId'] ?? null;
 
-        if (!$methodId) {
-            throw new BadRequestHttpException('The `methodId` is required');
+        $methodId = $data['methodId'] ?? null;
+        $backUrl = $data['backUrl'] ?? null;
+        if (!$methodId || !$backUrl) {
+            throw new BadRequestHttpException('The `methodId` and `backUrl` are required');
         }
 
         $payment = $order->getLastPayment();
@@ -113,6 +114,7 @@ final class SelectMollieMethodAction
             $gatewayConfig,
             $methodId,
             $isSubscription,
+            $backUrl,
             $customerMollieId,
         );
 
@@ -178,6 +180,7 @@ final class SelectMollieMethodAction
         GatewayConfigInterface $gatewayConfig,
         string $methodId,
         bool $isSubscription,
+        string $backUrl,
         ?string $customerMollieId,
     ): array {
         $divisor = $this->divisorProvider->getDivisor();
@@ -196,11 +199,6 @@ final class SelectMollieMethodAction
             UrlGeneratorInterface::ABSOLUTE_URL,
         );
 
-        $redirectUrl = $this->router->generate(
-            'sylius_mollie_api_shop_order_mollie_payment_status',
-            ['tokenValue' => $order->getTokenValue()],
-            UrlGeneratorInterface::ABSOLUTE_URL,
-        );
         $paymentData = [
             'method' => $methodId,
             'amount' => [
@@ -208,7 +206,7 @@ final class SelectMollieMethodAction
                 'value' => $this->intToStringConverter->convertIntToString($payment->getAmount(), $divisor),
             ],
             'description' => $this->paymentDescriptionProvider->getPaymentDescription($payment, $methodConfig, $order),
-            'redirectUrl' => $redirectUrl,
+            'redirectUrl' => $backUrl,
             'webhookUrl' => $webhookUrl,
             'metadata' => [
                 'order_id' => $order->getId(),

--- a/src/Api/Controller/SelectMollieMethodAction.php
+++ b/src/Api/Controller/SelectMollieMethodAction.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\MolliePlugin\Api\Controller;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Mollie\Api\Exceptions\ApiException;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\MolliePlugin\Client\MollieApiClient;
+use Sylius\MolliePlugin\Converter\IntToStringConverterInterface;
+use Sylius\MolliePlugin\Converter\OrderConverterInterface;
+use Sylius\MolliePlugin\Entity\GatewayConfigInterface;
+use Sylius\MolliePlugin\Entity\MollieCustomer;
+use Sylius\MolliePlugin\Entity\OrderInterface as MollieOrderInterface;
+use Sylius\MolliePlugin\Factory\MollieSubscriptionFactoryInterface;
+use Sylius\MolliePlugin\Logger\MollieLoggerActionInterface;
+use Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface;
+use Sylius\MolliePlugin\Payum\Factory\MollieSubscriptionGatewayFactory;
+use Sylius\MolliePlugin\Provider\DivisorProviderInterface;
+use Sylius\MolliePlugin\Provider\PaymentDescriptionProviderInterface;
+use Sylius\MolliePlugin\Repository\MollieGatewayConfigRepositoryInterface;
+use Sylius\MolliePlugin\Repository\MollieSubscriptionRepositoryInterface;
+use Sylius\MolliePlugin\Resolver\MollieApiClientKeyResolverInterface;
+use Sylius\MolliePlugin\Resolver\PaymentLocaleResolverInterface;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class SelectMollieMethodAction
+{
+    public function __construct(
+        private readonly OrderRepositoryInterface $orderRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly IntToStringConverterInterface $intToStringConverter,
+        private readonly UrlGeneratorInterface $router,
+        private readonly MollieApiClientKeyResolverInterface $apiClientKeyResolver,
+        private readonly MollieGatewayFactoryCheckerInterface $mollieGatewayFactoryChecker,
+        private readonly PaymentDescriptionProviderInterface $paymentDescriptionProvider,
+        private readonly PaymentLocaleResolverInterface $paymentLocaleResolver,
+        private readonly DivisorProviderInterface $divisorProvider,
+        private readonly MollieGatewayConfigRepositoryInterface $mollieGatewayConfigRepository,
+        private readonly RepositoryInterface $mollieCustomerRepository,
+        private readonly MollieSubscriptionFactoryInterface $subscriptionFactory,
+        private readonly MollieSubscriptionRepositoryInterface $subscriptionRepository,
+        private readonly MollieLoggerActionInterface $logger,
+        private readonly OrderConverterInterface $orderConverter,
+    ) {
+    }
+
+    public function __invoke(string $tokenValue, Request $request): JsonResponse
+    {
+        $order = $this->orderRepository->findOneByTokenValue($tokenValue);
+
+        if (!$order instanceof OrderInterface) {
+            throw new NotFoundHttpException(sprintf('Order with token "%s" not found', $tokenValue));
+        }
+
+        $data = json_decode($request->getContent(), true);
+        $methodId = $data['methodId'] ?? null;
+
+        if (!$methodId) {
+            throw new BadRequestHttpException('The `methodId` is required');
+        }
+
+        $payment = $order->getLastPayment();
+        if (!$payment instanceof PaymentInterface) {
+            throw new NotFoundHttpException('No payment found');
+        }
+
+        $paymentMethod = $payment->getMethod();
+        if (!$paymentMethod instanceof PaymentMethodInterface) {
+            throw new NotFoundHttpException('No payment method found');
+        }
+
+        $gatewayConfig = $paymentMethod->getGatewayConfig();
+        if (!$gatewayConfig instanceof GatewayConfigInterface) {
+            throw new NotFoundHttpException('No gateway config found');
+        }
+
+        if (!$this->mollieGatewayFactoryChecker->isMollieGateway($gatewayConfig)) {
+            throw new BadRequestException('The payment method is not using Mollie');
+        }
+
+        $mollieApiClient = $this->apiClientKeyResolver->getClientWithKey($order);
+
+        $customerMollieId = null;
+        $isSubscription = $gatewayConfig->getFactoryName() === MollieSubscriptionGatewayFactory::FACTORY_NAME;
+
+        if ($isSubscription) {
+            $customerMollieId = $this->findOrCreateMollieCustomer($mollieApiClient, $order);
+        }
+
+        $paymentData = $this->createPaymentData(
+            $order,
+            $payment,
+            $gatewayConfig,
+            $methodId,
+            $isSubscription,
+            $customerMollieId,
+        );
+
+        try {
+            $molliePayment = $mollieApiClient->payments->create($paymentData);
+
+            $checkoutUrl = $molliePayment->_links->checkout->href ?? null;
+            if (!$checkoutUrl) {
+                $this->logger->addNegativeLog(sprintf('No checkout URL returned from Mollie for order %s', $order->getNumber()));
+
+                return new JsonResponse(
+                    ['error' => 'No checkout URL returned from Mollie'],
+                    Response::HTTP_INTERNAL_SERVER_ERROR,
+                );
+            }
+        } catch (ApiException $exception) {
+            $this->logger->addNegativeLog(sprintf(
+                'Creating payment in Mollie failed for order %s with: %s',
+                $order->getNumber(),
+                $exception->getMessage(),
+            ));
+
+            return new JsonResponse(
+                ['error' => 'Creating payment in Mollie failed.'],
+                Response::HTTP_INTERNAL_SERVER_ERROR,
+            );
+        }
+
+        $details = [
+            'molliePaymentMethods' => $methodId,
+            'payment_mollie_id' => $molliePayment->id,
+            'cartToken' => null,
+            'saveCardInfo' => '0',
+            'useSavedCards' => '0',
+            'webhookUrl' => $paymentData['webhookUrl'],
+            'backurl' => $paymentData['redirectUrl'],
+        ];
+
+        if ($isSubscription) {
+            $details['customer_mollie_id'] = $customerMollieId;
+        }
+
+        $payment->setDetails($details);
+
+        if ($isSubscription && $order instanceof MollieOrderInterface) {
+            $this->createInternalSubscriptions($order, $paymentData, $customerMollieId);
+        }
+
+        $this->entityManager->flush();
+
+        return new JsonResponse([
+            'success' => true,
+            'methodId' => $methodId,
+            'checkoutUrl' => $checkoutUrl,
+            'paymentId' => $molliePayment->id,
+        ]);
+    }
+
+    private function createPaymentData(
+        OrderInterface $order,
+        PaymentInterface $payment,
+        GatewayConfigInterface $gatewayConfig,
+        string $methodId,
+        bool $isSubscription,
+        ?string $customerMollieId,
+    ): array {
+        $divisor = $this->divisorProvider->getDivisor();
+
+        $methodConfig = $this->mollieGatewayConfigRepository->findOneActiveByGatewayNameAndMethod(
+            $gatewayConfig->getGatewayName(),
+            $methodId,
+        );
+        if (null === $methodConfig) {
+            throw new BadRequestHttpException(sprintf('Mollie method "%s" cannot be selected', $methodId));
+        }
+
+        $webhookUrl = $this->router->generate(
+            'sylius_mollie_shop_payment_webhook',
+            ['_locale' => $order->getLocaleCode() ?? 'en_US'],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+
+        $redirectUrl = $this->router->generate(
+            'sylius_mollie_api_shop_order_mollie_payment_status',
+            ['tokenValue' => $order->getTokenValue()],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+        $paymentData = [
+            'method' => $methodId,
+            'amount' => [
+                'currency' => $payment->getCurrencyCode(),
+                'value' => $this->intToStringConverter->convertIntToString($payment->getAmount(), $divisor),
+            ],
+            'description' => $this->paymentDescriptionProvider->getPaymentDescription($payment, $methodConfig, $order),
+            'redirectUrl' => $redirectUrl,
+            'webhookUrl' => $webhookUrl,
+            'metadata' => [
+                'order_id' => $order->getId(),
+                'customer_id' => $order->getCustomer()?->getId(),
+                'molliePaymentMethods' => $methodId,
+            ],
+        ];
+
+        $converted = $this->orderConverter->convert($order, $paymentData, $divisor, $methodConfig);
+        $paymentData['billingAddress'] = $converted['billingAddress'];
+        $paymentData['shippingAddress'] = $converted['shippingAddress'];
+        $paymentData['lines'] = array_map(
+            static fn (array $line): array => [
+                'description' => $line['name'] ?? '',
+                'type' => $line['type'] ?? 'physical',
+                'quantity' => $line['quantity'],
+                'unitPrice' => $line['unitPrice'],
+                'totalAmount' => $line['totalAmount'],
+                'vatRate' => $line['vatRate'],
+                'vatAmount' => $line['vatAmount'],
+            ],
+            $converted['lines'],
+        );
+
+        $locale = $this->paymentLocaleResolver->resolveFromOrder($order);
+
+        if ($locale !== null) {
+            $paymentData['locale'] = $locale;
+        }
+
+        if ($isSubscription) {
+            $paymentData['customerId'] = $customerMollieId;
+            $paymentData['sequenceType'] = 'first';
+            $paymentData['metadata']['sequenceType'] = 'first';
+        }
+
+        return $paymentData;
+    }
+
+    private function findOrCreateMollieCustomer(MollieApiClient $mollieApiClient, OrderInterface $order): string
+    {
+        $email = $order->getCustomer()?->getEmail();
+
+        /** @var ?MollieCustomer $customer */
+        $customer = $this->mollieCustomerRepository->findOneBy(['email' => $email]);
+        if (null === $customer) {
+            $customer = new MollieCustomer();
+            $customer->setEmail($email);
+        }
+
+        if (null === $customer->getProfileId()) {
+            $customerMollie = $mollieApiClient->customers->create([
+                'name' => $order->getCustomer()?->getFullName(),
+                'email' => $email,
+            ]);
+            $customer->setProfileId($customerMollie->id);
+
+            $this->mollieCustomerRepository->add($customer);
+        }
+
+        return $customer->getProfileId();
+    }
+
+    private function createInternalSubscriptions(
+        MollieOrderInterface $order,
+        array $paymentData,
+        ?string $customerMollieId,
+    ): void {
+        foreach ($order->getRecurringItems() as $item) {
+            $subscription = $this->subscriptionFactory->createFromFirstOrderWithOrderItemAndPaymentConfiguration(
+                $order,
+                $item,
+                $paymentData,
+            );
+            $subscription->getSubscriptionConfiguration()->setCustomerId($customerMollieId);
+            $this->subscriptionRepository->add($subscription);
+        }
+    }
+}

--- a/src/Api/OpenApi/MollieDocumentationModifier.php
+++ b/src/Api/OpenApi/MollieDocumentationModifier.php
@@ -1,0 +1,179 @@
+<?php
+
+/*
+ * This file is part of the Sylius Mollie Plugin package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\MolliePlugin\Api\OpenApi;
+
+use ApiPlatform\OpenApi\Model\Operation;
+use ApiPlatform\OpenApi\Model\Parameter;
+use ApiPlatform\OpenApi\Model\PathItem;
+use ApiPlatform\OpenApi\Model\Paths;
+use ApiPlatform\OpenApi\Model\RequestBody;
+use ApiPlatform\OpenApi\Model\Response as ResponseModel;
+use ApiPlatform\OpenApi\OpenApi;
+use Sylius\Bundle\ApiBundle\OpenApi\Documentation\DocumentationModifierInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+final readonly class MollieDocumentationModifier implements DocumentationModifierInterface
+{
+    public function __construct(
+        private string $shopApiRoute,
+    ) {
+    }
+
+    public function modify(OpenApi $docs): OpenApi
+    {
+        $paths = $docs->getPaths();
+        $schemas = $docs->getComponents()->getSchemas();
+
+        $schemas = $this->addSchemas($schemas);
+        $this->addPaths($paths);
+
+        return $docs
+            ->withPaths($paths)
+            ->withComponents($docs->getComponents()->withSchemas($schemas))
+        ;
+    }
+
+    private function addPaths(Paths $paths): void
+    {
+        $tokenParameter = new Parameter(
+            name: 'tokenValue',
+            in: 'path',
+            description: 'The token of the order',
+            required: true,
+            schema: ['type' => 'string'],
+        );
+
+        $methodsPath = sprintf('%s/orders/{tokenValue}/mollie-methods', $this->shopApiRoute);
+        $paths->addPath($methodsPath, new PathItem(
+            ref: 'MollieMethods',
+            get: new Operation(
+                operationId: 'sylius_mollie_api_shop_order_mollie_methods',
+                tags: ['Mollie'],
+                responses: [
+                    Response::HTTP_OK => new ResponseModel(
+                        description: 'List of available Mollie payment methods',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'schema' => [
+                                    'type' => 'array',
+                                    'items' => ['$ref' => '#/components/schemas/MollieMethod'],
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+                summary: 'Get available Mollie payment methods for an order',
+                parameters: [$tokenParameter],
+            ),
+            post: new Operation(
+                operationId: 'sylius_mollie_api_shop_order_mollie_select_method',
+                tags: ['Mollie'],
+                responses: [
+                    Response::HTTP_OK => new ResponseModel(
+                        description: 'Mollie payment created successfully',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'schema' => ['$ref' => '#/components/schemas/MollieSelectMethodResponse'],
+                            ],
+                        ]),
+                    ),
+                ],
+                summary: 'Select a Mollie payment method and create a payment',
+                parameters: [$tokenParameter],
+                requestBody: new RequestBody(
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => ['$ref' => '#/components/schemas/MollieSelectMethodRequest'],
+                        ],
+                    ]),
+                    required: true,
+                ),
+            ),
+        ));
+
+        $statusPath = sprintf('%s/orders/{tokenValue}/mollie-status', $this->shopApiRoute);
+        $paths->addPath($statusPath, new PathItem(
+            ref: 'MolliePaymentStatus',
+            get: new Operation(
+                operationId: 'sylius_mollie_api_shop_order_mollie_payment_status',
+                tags: ['Mollie'],
+                responses: [
+                    Response::HTTP_OK => new ResponseModel(
+                        description: 'Current payment status',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'schema' => ['$ref' => '#/components/schemas/MolliePaymentStatus'],
+                            ],
+                        ]),
+                    ),
+                ],
+                summary: 'Get Mollie payment status and update Sylius payment state',
+                parameters: [$tokenParameter],
+            ),
+        ));
+    }
+
+    /**
+     * @param array<string, mixed>|\ArrayObject<string, mixed> $schemas
+     *
+     * @return array<string, mixed>|\ArrayObject<string, mixed>
+     */
+    private function addSchemas(array|\ArrayObject $schemas): array|\ArrayObject
+    {
+        $schemas['MollieMethod'] = [
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'string', 'example' => 'klarna'],
+                'label' => ['type' => 'string', 'example' => 'Klarna'],
+                'image' => ['type' => 'string', 'nullable' => true, 'example' => 'https://www.mollie.com/external/icons/payment-methods/klarna.svg'],
+                'paymentFee' => [
+                    'type' => 'object',
+                    'nullable' => true,
+                    'properties' => [
+                        'type' => ['type' => 'string', 'nullable' => true],
+                        'fixedAmount' => ['type' => 'number', 'nullable' => true],
+                        'percentage' => ['type' => 'number', 'nullable' => true],
+                        'surchargeLimit' => ['type' => 'number', 'nullable' => true],
+                    ],
+                ],
+            ],
+        ];
+
+        $schemas['MollieSelectMethodRequest'] = [
+            'type' => 'object',
+            'required' => ['methodId'],
+            'properties' => [
+                'methodId' => ['type' => 'string', 'example' => 'ideal'],
+            ],
+        ];
+
+        $schemas['MollieSelectMethodResponse'] = [
+            'type' => 'object',
+            'properties' => [
+                'methodId' => ['type' => 'string'],
+                'checkoutUrl' => ['type' => 'string'],
+            ],
+        ];
+
+        $schemas['MolliePaymentStatus'] = [
+            'type' => 'object',
+            'properties' => [
+                'orderToken' => ['type' => 'string'],
+                'paymentState' => ['type' => 'string'],
+            ],
+        ];
+
+        return $schemas;
+    }
+}

--- a/src/Api/OpenApi/MollieDocumentationModifier.php
+++ b/src/Api/OpenApi/MollieDocumentationModifier.php
@@ -152,9 +152,10 @@ final readonly class MollieDocumentationModifier implements DocumentationModifie
 
         $schemas['MollieSelectMethodRequest'] = [
             'type' => 'object',
-            'required' => ['methodId'],
+            'required' => ['methodId', 'backUrl'],
             'properties' => [
                 'methodId' => ['type' => 'string', 'example' => 'ideal'],
+                'backUrl' => ['type' => 'string', 'example' => 'https://example.com/return-here-after-payment'],
             ],
         ];
 
@@ -169,7 +170,6 @@ final readonly class MollieDocumentationModifier implements DocumentationModifie
         $schemas['MolliePaymentStatus'] = [
             'type' => 'object',
             'properties' => [
-                'orderToken' => ['type' => 'string'],
                 'paymentState' => ['type' => 'string'],
             ],
         ];

--- a/src/Controller/Shop/PaymentWebhookController.php
+++ b/src/Controller/Shop/PaymentWebhookController.php
@@ -21,6 +21,7 @@ use Sylius\Component\Order\Repository\OrderRepositoryInterface;
 use Sylius\Component\Payment\Model\PaymentInterface;
 use Sylius\MolliePlugin\Client\MollieApiClient;
 use Sylius\MolliePlugin\Entity\OrderInterface;
+use Sylius\MolliePlugin\Logger\MollieLoggerActionInterface;
 use Sylius\MolliePlugin\Resolver\MollieApiClientKeyResolverInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -33,14 +34,35 @@ class PaymentWebhookController
         private readonly MollieApiClientKeyResolverInterface $apiClientKeyResolver,
         private readonly OrderRepositoryInterface $orderRepository,
         private readonly PaymentRepositoryInterface $paymentRepository,
+        private readonly ?MollieLoggerActionInterface $logger = null,
     ) {
+        if (null === $this->logger) {
+            trigger_deprecation(
+                'sylius/mollie-plugin',
+                '3.2',
+                'Not passing MollieLoggerActionInterface to %s is deprecated and will not be supported in the future.',
+                self::class,
+            );
+        }
     }
 
-    /** @throws ApiException */
     public function __invoke(Request $request): Response
     {
         $this->mollieApiClient->setApiKey($this->apiClientKeyResolver->getClientWithKey()->getApiKey());
-        $molliePayment = $this->mollieApiClient->payments->get($request->get('id'));
+
+        $molliePaymentId = $request->get('id');
+
+        try {
+            $molliePayment = $this->mollieApiClient->payments->get($molliePaymentId);
+        } catch (ApiException $e) {
+            $this->logger?->addLog(sprintf(
+                'Mollie Webhook: Could not retrieve payment with id %s. Error: %s',
+                $molliePaymentId,
+                $e->getMessage(),
+            ));
+
+            return new JsonResponse(Response::HTTP_OK);
+        }
 
         /** @var OrderInterface|null $order */
         $order = $this->orderRepository->findOneBy(['id' => $request->get('orderId')]);

--- a/src/Repository/Query/OrderByTokenForAvailableMethodsQuery.php
+++ b/src/Repository/Query/OrderByTokenForAvailableMethodsQuery.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius Mollie Plugin package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\MolliePlugin\Repository\Query;
+
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\MolliePlugin\Entity\OrderInterface;
+
+final class OrderByTokenForAvailableMethodsQuery implements OrderByTokenForAvailableMethodsQueryInterface
+{
+    /** @param OrderRepositoryInterface&EntityRepository $orderRepository */
+    public function __construct(
+        private OrderRepositoryInterface $orderRepository,
+    ) {
+    }
+
+    public function getOrder(string $tokenValue): ?OrderInterface
+    {
+        return $this->orderRepository->createQueryBuilder('o')
+            ->andWhere('o.tokenValue = :tokenValue')
+            ->andWhere('o.state IN (:states)')
+            ->setParameter('tokenValue', $tokenValue)
+            ->setParameter('states', [
+                OrderInterface::STATE_NEW,
+                OrderInterface::STATE_CART,
+            ])
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+}

--- a/src/Repository/Query/OrderByTokenForAvailableMethodsQueryInterface.php
+++ b/src/Repository/Query/OrderByTokenForAvailableMethodsQueryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius Mollie Plugin package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\MolliePlugin\Repository\Query;
+
+use Sylius\MolliePlugin\Entity\OrderInterface;
+
+interface OrderByTokenForAvailableMethodsQueryInterface
+{
+    public function getOrder(string $tokenValue): ? OrderInterface;
+}


### PR DESCRIPTION
Improved checkout flow that allows purely API handling of Mollie payment within Sylius, with 3 endpoints:
1. `sylius_mollie_api_shop_order_mollie_methods` (GET `api/v2/shop/orders/{token}/mollie-methods`) - gets all methods available for the order/cart
2. `sylius_mollie_api_shop_order_mollie_select_method` (POST `api/v2/shop/orders/{token}/mollie-methods`) - handles payment logic and returns a ready link to pay on Mollie (requires a `methodId` from the previous endpoint as well as a `backUrl` pointing to where the customer will arrive after paying)
3. `sylius_mollie_api_shop_order_mollie_payment_status` (GET `api/v2/shop/orders/{token}/mollie-status`) - checks the state of the payment on Mollie and cascades it to Sylius