### PR TITLE
[Integration Mollie 3] Omit cardToken and method from off-session recurring charge

### DIFF
--- a/src/Payum/Action/CreateOnDemandPaymentAction.php
+++ b/src/Payum/Action/CreateOnDemandPaymentAction.php
@@ -39,8 +39,6 @@ final class CreateOnDemandPaymentAction extends BaseApiAwareAction implements Ga
 
         try {
             $paymentSettings = [
-                'method' => $details['metadata']['molliePaymentMethods'],
-                'cardToken' => $details['metadata']['cartToken'],
                 'amount' => $details['amount'],
                 'customerId' => $details['customerId'] ?? null,
                 'description' => $details['description'],
@@ -49,6 +47,17 @@ final class CreateOnDemandPaymentAction extends BaseApiAwareAction implements Ga
                 'mandateId' => $details['mandateId'],
                 'sequenceType' => 'recurring',
             ];
+
+            $method = $details['metadata']['molliePaymentMethods'] ?? null;
+            if (null !== $method && '' !== $method) {
+                $paymentSettings['method'] = $method;
+            }
+
+            $cardToken = $details['metadata']['cartToken'] ?? null;
+            if (null !== $cardToken && '' !== $cardToken) {
+                $paymentSettings['cardToken'] = $cardToken;
+            }
+
             /** @throws ApiException|\Exception */
             $payment = $this->mollieApiClient->payments->create($paymentSettings);
         } catch (ApiException $e) {

--- a/src/Payum/Action/Subscription/ConvertMollieSubscriptionPaymentAction.php
+++ b/src/Payum/Action/Subscription/ConvertMollieSubscriptionPaymentAction.php
@@ -73,7 +73,7 @@ final class ConvertMollieSubscriptionPaymentAction extends BaseApiAwareAction im
         $amount = $this->intToStringConverter->convertIntToString($payment->getAmount(), $divisor);
         $paymentOptions = $payment->getDetails();
 
-        $cartToken = $paymentOptions['cartToken'];
+        $cartToken = $paymentOptions['cartToken'] ?? null;
         $sequenceType = array_key_exists(
             'recurring',
             $paymentOptions,

--- a/tests/Unit/Action/CreateOnDemandPaymentActionTest.php
+++ b/tests/Unit/Action/CreateOnDemandPaymentActionTest.php
@@ -71,11 +71,11 @@ final class CreateOnDemandPaymentActionTest extends TestCase
             ->expects($this->once())
             ->method('create')
             ->with($this->callback(static function (array $payload): bool {
-                return false === array_key_exists('cardToken', $payload)
-                    && false === array_key_exists('method', $payload)
-                    && 'recurring' === $payload['sequenceType']
-                    && 'cst_abc' === $payload['customerId']
-                    && 'mdt_xyz' === $payload['mandateId'];
+                return false === array_key_exists('cardToken', $payload) &&
+                    false === array_key_exists('method', $payload) &&
+                    'recurring' === $payload['sequenceType'] &&
+                    'cst_abc' === $payload['customerId'] &&
+                    'mdt_xyz' === $payload['mandateId'];
             }))
             ->willReturn($payment)
         ;
@@ -105,8 +105,8 @@ final class CreateOnDemandPaymentActionTest extends TestCase
             ->expects($this->once())
             ->method('create')
             ->with($this->callback(static function (array $payload): bool {
-                return 'creditcard' === ($payload['method'] ?? null)
-                    && 'tkn_live' === ($payload['cardToken'] ?? null);
+                return 'creditcard' === ($payload['method'] ?? null) &&
+                    'tkn_live' === ($payload['cardToken'] ?? null);
             }))
             ->willReturn($payment)
         ;
@@ -136,11 +136,11 @@ final class CreateOnDemandPaymentActionTest extends TestCase
             ->expects($this->once())
             ->method('create')
             ->with($this->callback(static function (array $payload): bool {
-                return false === array_key_exists('cardToken', $payload)
-                    && false === array_key_exists('method', $payload)
-                    && 'recurring' === $payload['sequenceType']
-                    && 'cst_abc' === $payload['customerId']
-                    && 'mdt_xyz' === $payload['mandateId'];
+                return false === array_key_exists('cardToken', $payload) &&
+                    false === array_key_exists('method', $payload) &&
+                    'recurring' === $payload['sequenceType'] &&
+                    'cst_abc' === $payload['customerId'] &&
+                    'mdt_xyz' === $payload['mandateId'];
             }))
             ->willReturn($payment)
         ;

--- a/tests/Unit/Action/CreateOnDemandPaymentActionTest.php
+++ b/tests/Unit/Action/CreateOnDemandPaymentActionTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the Sylius Mollie Plugin package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\MolliePlugin\Unit\Action;
+
+use Mollie\Api\Endpoints\PaymentEndpoint;
+use Mollie\Api\Resources\Payment;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\MolliePlugin\Client\MollieApiClient;
+use Sylius\MolliePlugin\Client\Parser\ApiExceptionParserInterface;
+use Sylius\MolliePlugin\Logger\MollieLoggerActionInterface;
+use Sylius\MolliePlugin\Payum\Action\CreateOnDemandPaymentAction;
+use Sylius\MolliePlugin\Payum\Request\Subscription\CreateOnDemandSubscriptionPayment;
+
+final class CreateOnDemandPaymentActionTest extends TestCase
+{
+    private MollieLoggerActionInterface $logger;
+
+    private ApiExceptionParserInterface $apiExceptionParser;
+
+    private MollieApiClient $mollieApiClient;
+
+    private PaymentEndpoint $paymentEndpoint;
+
+    private CreateOnDemandPaymentAction $action;
+
+    protected function setUp(): void
+    {
+        $this->logger = $this->createMock(MollieLoggerActionInterface::class);
+        $this->apiExceptionParser = $this->createMock(ApiExceptionParserInterface::class);
+
+        $this->action = new CreateOnDemandPaymentAction($this->logger, $this->apiExceptionParser);
+
+        $this->mollieApiClient = $this->createMock(MollieApiClient::class);
+        $this->paymentEndpoint = $this->createMock(PaymentEndpoint::class);
+        $this->mollieApiClient->payments = $this->paymentEndpoint;
+
+        $this->action->setApi($this->mollieApiClient);
+    }
+
+    public function testItChargesRecurringWithoutCardTokenAndMethodWhenAbsent(): void
+    {
+        $details = [
+            'amount' => ['value' => '10.00', 'currency' => 'EUR'],
+            'customerId' => 'cst_abc',
+            'mandateId' => 'mdt_xyz',
+            'description' => 'Subscription renewal',
+            'webhookUrl' => 'https://shop.example.com/update-payment',
+            'metadata' => [
+                'sequenceType' => 'recurring',
+                'molliePaymentMethods' => null,
+                'cartToken' => null,
+            ],
+        ];
+
+        $payment = new Payment($this->mollieApiClient);
+        $payment->id = 'tr_123';
+
+        $this->paymentEndpoint
+            ->expects($this->once())
+            ->method('create')
+            ->with($this->callback(static function (array $payload): bool {
+                return false === array_key_exists('cardToken', $payload)
+                    && false === array_key_exists('method', $payload)
+                    && 'recurring' === $payload['sequenceType']
+                    && 'cst_abc' === $payload['customerId']
+                    && 'mdt_xyz' === $payload['mandateId'];
+            }))
+            ->willReturn($payment)
+        ;
+
+        $this->action->execute(new CreateOnDemandSubscriptionPayment(new ArrayObject($details)));
+    }
+
+    public function testItKeepsMethodAndCardTokenWhenPresent(): void
+    {
+        $details = [
+            'amount' => ['value' => '10.00', 'currency' => 'EUR'],
+            'customerId' => 'cst_abc',
+            'mandateId' => 'mdt_xyz',
+            'description' => 'Subscription renewal',
+            'webhookUrl' => 'https://shop.example.com/update-payment',
+            'metadata' => [
+                'sequenceType' => 'recurring',
+                'molliePaymentMethods' => 'creditcard',
+                'cartToken' => 'tkn_live',
+            ],
+        ];
+
+        $payment = new Payment($this->mollieApiClient);
+        $payment->id = 'tr_456';
+
+        $this->paymentEndpoint
+            ->expects($this->once())
+            ->method('create')
+            ->with($this->callback(static function (array $payload): bool {
+                return 'creditcard' === ($payload['method'] ?? null)
+                    && 'tkn_live' === ($payload['cardToken'] ?? null);
+            }))
+            ->willReturn($payment)
+        ;
+
+        $this->action->execute(new CreateOnDemandSubscriptionPayment(new ArrayObject($details)));
+    }
+
+    public function testItOmitsMethodAndCardTokenWhenBlankString(): void
+    {
+        $details = [
+            'amount' => ['value' => '10.00', 'currency' => 'EUR'],
+            'customerId' => 'cst_abc',
+            'mandateId' => 'mdt_xyz',
+            'description' => 'Subscription renewal',
+            'webhookUrl' => 'https://shop.example.com/update-payment',
+            'metadata' => [
+                'sequenceType' => 'recurring',
+                'molliePaymentMethods' => '',
+                'cartToken' => '',
+            ],
+        ];
+
+        $payment = new Payment($this->mollieApiClient);
+        $payment->id = 'tr_789';
+
+        $this->paymentEndpoint
+            ->expects($this->once())
+            ->method('create')
+            ->with($this->callback(static function (array $payload): bool {
+                return false === array_key_exists('cardToken', $payload)
+                    && false === array_key_exists('method', $payload)
+                    && 'recurring' === $payload['sequenceType']
+                    && 'cst_abc' === $payload['customerId']
+                    && 'mdt_xyz' === $payload['mandateId'];
+            }))
+            ->willReturn($payment)
+        ;
+
+        $this->action->execute(new CreateOnDemandSubscriptionPayment(new ArrayObject($details)));
+    }
+}

--- a/tests/Unit/Action/Subscription/ConvertMollieSubscriptionPaymentActionTest.php
+++ b/tests/Unit/Action/Subscription/ConvertMollieSubscriptionPaymentActionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Sylius Mollie Plugin package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\MolliePlugin\Unit\Action\Subscription;
+
+use Payum\Core\GatewayInterface;
+use Payum\Core\Request\Convert;
+use Payum\Core\Request\GetCurrency;
+use Payum\Core\Security\TokenInterface;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Customer\Context\CustomerContextInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\MolliePlugin\Client\MollieApiClient;
+use Sylius\MolliePlugin\Converter\IntToStringConverterInterface;
+use Sylius\MolliePlugin\Converter\OrderConverterInterface;
+use Sylius\MolliePlugin\Entity\OrderInterface;
+use Sylius\MolliePlugin\Payum\Action\Subscription\ConvertMollieSubscriptionPaymentAction;
+use Sylius\MolliePlugin\Payum\Request\CreateCustomer;
+use Sylius\MolliePlugin\Provider\DivisorProviderInterface;
+use Sylius\MolliePlugin\Provider\PaymentDescriptionProviderInterface;
+use Sylius\MolliePlugin\Resolver\PaymentLocaleResolverInterface;
+
+final class ConvertMollieSubscriptionPaymentActionTest extends TestCase
+{
+    private ConvertMollieSubscriptionPaymentAction $action;
+
+    private GatewayInterface $gateway;
+
+    protected function setUp(): void
+    {
+        $divisorProvider = $this->createMock(DivisorProviderInterface::class);
+        $divisorProvider->method('getDivisorForCurrency')->willReturn(100);
+
+        $intToStringConverter = $this->createMock(IntToStringConverterInterface::class);
+        $intToStringConverter->method('convertIntToString')->willReturn('10.00');
+
+        $this->action = new ConvertMollieSubscriptionPaymentAction(
+            $this->createMock(PaymentDescriptionProviderInterface::class),
+            $this->createMock(RepositoryInterface::class),
+            $this->createMock(OrderConverterInterface::class),
+            $this->createMock(CustomerContextInterface::class),
+            $this->createMock(PaymentLocaleResolverInterface::class),
+            $intToStringConverter,
+            $divisorProvider,
+        );
+
+        $this->gateway = $this->createMock(GatewayInterface::class);
+        $this->gateway->method('execute')->willReturnCallback(static function ($request): void {
+            if ($request instanceof GetCurrency) {
+                $request->code = 'EUR';
+            }
+            if ($request instanceof CreateCustomer) {
+                $model = $request->getModel();
+                $model['customer_mollie_id'] = 'cst_abc';
+            }
+        });
+        $this->action->setGateway($this->gateway);
+        $this->action->setApi($this->createMock(MollieApiClient::class));
+    }
+
+    public function testItDoesNotFailWhenCartTokenIsAbsentFromPaymentDetails(): void
+    {
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->method('getId')->willReturn(1);
+        $customer->method('getFullName')->willReturn('Jane Doe');
+        $customer->method('getEmail')->willReturn('jane@example.com');
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getRecurringSequenceIndex')->willReturn(0);
+        $order->method('getCustomer')->willReturn($customer);
+        $order->method('getNumber')->willReturn('000001');
+        $order->method('getId')->willReturn(10);
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getCurrencyCode')->willReturn('EUR');
+        $payment->method('getAmount')->willReturn(1000);
+        // payment details deliberately WITHOUT 'cartToken' (off-session renewal)
+        $payment->method('getDetails')->willReturn([
+            'recurring' => true,
+            'mandateId' => 'mdt_xyz',
+            'metadata' => ['molliePaymentMethods' => null],
+        ]);
+
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getGatewayName')->willReturn('mollie');
+
+        $request = new Convert($payment, 'array', $token);
+
+        $this->action->execute($request);
+
+        $result = $request->getResult();
+        self::assertSame('recurring', $result['sequenceType']);
+        self::assertSame('mdt_xyz', $result['mandateId']);
+        self::assertSame('cst_abc', $result['customerId']);
+    }
+}


### PR DESCRIPTION
## Third PR from the series related with feature Integration with Mollie ##

  ## Goal

  A recurring (off-session) Mollie charge must not include fields the PSP does not expect. When Mollie charges against an existing mandate it derives the payment method from that
  mandate — sending `method` or `cardToken` in the payload is unnecessary and can cause API errors during automated renewal cycles.

  This PR fixes the recurring charge payload to contain only what Mollie requires for mandate-based charging. SubscriptionPlugin remains the source of truth for scheduling; this change
  makes the Mollie engine behave correctly when it executes that charge.

  ## How it works

  `CreateOnDemandPaymentAction` builds the `payments->create` payload from the mandate identifiers (`customerId`, `mandateId`), amount, description, webhook URL, metadata, and
  `sequenceType: recurring`. `method` and `cardToken` are added to the payload **only when explicitly present and non-empty**. Keys are omitted entirely rather than set to `null` — the
  Mollie SDK serializes via raw `json_encode` with no null-stripping, so a `null` value would still reach the API.

  `ConvertMollieSubscriptionPaymentAction` gains a null-guard on the `cartToken` metadata read that feeds into this flow.

  ## Scope

  The fix targets the `sequenceType: recurring` path only. The `sequenceType: first` path (`CreateOnDemandSubscriptionAction`) is untouched. `idempotencyKey` is out of scope — belongs
  to a later PR.

  ## Pattern

  Conditional payload construction — include a field only when it carries a meaningful value, omit otherwise. This is the **HOW to charge** layer for the off-session recurring case.
