### PR TITLE
Fix QR code popup

### DIFF
--- a/assets/shop/js/mollie/app.js
+++ b/assets/shop/js/mollie/app.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     let disableValidationMollieComponents = false;
     let selectedValue = false;
-    let orderToken = null;
+    let orderId = null;
     let qrCodeInterval = null;
 
     showQrCodePopUp();
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (!mollieData) {
         return;
     }
+
     const orderTotalRow = document.getElementById('sylius-shop-checkout-summary-order-total');
     const initialOrderTotal = orderTotalRow ? orderTotalRow.textContent : null;
     const cardActiveClass = 'online-payment__item--active';
@@ -174,8 +175,8 @@ document.addEventListener('DOMContentLoaded', function () {
             .then((response) => response.json())
             .then((data) => {
                 let qrCode = data.qrCode;
-                if (orderToken === null) {
-                    orderToken = data.orderToken;
+                if (orderId === null) {
+                    orderId = data.orderId;
                 }
 
                 if (qrCode) {
@@ -184,7 +185,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         qrCodeMethod = 'iDeal';
                     }
                     createPopup(qrCode, qrCodeMethod);
-                    qrCodeInterval = setInterval(() => checkQrCode(url + '?orderToken=' + orderToken), 1000);
+                    qrCodeInterval = setInterval(() => checkQrCode(url + '?orderId=' + orderId), 1000);
                 }
             });
     }
@@ -198,7 +199,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     let qrBoxElement = document.getElementById('sylius-shop-checkout-summary-qr-box')
                     if (qrBoxElement) {
                         let thankYouPageUrl = qrBoxElement.getAttribute('data-thankYouPage');
-                        window.location.href = thankYouPageUrl + '?orderToken=' + orderToken;
+                        window.location.href = thankYouPageUrl + '?orderId=' + orderId;
                     }
                 }
             });

--- a/assets/shop/js/mollie/app.js
+++ b/assets/shop/js/mollie/app.js
@@ -2,14 +2,17 @@ const {Mollie} = window;
 
 document.addEventListener('DOMContentLoaded', function () {
     const mollieData = document.querySelector('.online-online-payment__container');
-    if (!mollieData) {
-        return;
-    }
 
     let disableValidationMollieComponents = false;
     let selectedValue = false;
     let orderToken = null;
     let qrCodeInterval = null;
+
+    showQrCodePopUp();
+
+    if (!mollieData) {
+        return;
+    }
     const orderTotalRow = document.getElementById('sylius-shop-checkout-summary-order-total');
     const initialOrderTotal = orderTotalRow ? orderTotalRow.textContent : null;
     const cardActiveClass = 'online-payment__item--active';
@@ -238,8 +241,6 @@ document.addEventListener('DOMContentLoaded', function () {
             fetchQrCode(qrCodeGetUrl);
         }
     }
-
-    showQrCodePopUp();
 
     function createPopup(qrCode, qrCodeMethod) {
         // Create popup container

--- a/config/services/controller/shop.xml
+++ b/config/services/controller/shop.xml
@@ -44,6 +44,7 @@
             <argument type="service" id="router" />
             <argument type="service" id="sylius_mollie.repository.mollie_gateway_config"/>
             <argument type="service" id="sylius_mollie.converter.int_to_string"/>
+            <argument type="service" id="sylius.assigner.order_token.unique_id_based"/>
         </service>
 
         <service id="sylius_mollie.controller.shop.credit_card_translation" class="Sylius\MolliePlugin\Controller\Shop\CreditCardTranslationController">

--- a/config/services/controller/shop.xml
+++ b/config/services/controller/shop.xml
@@ -44,7 +44,6 @@
             <argument type="service" id="router" />
             <argument type="service" id="sylius_mollie.repository.mollie_gateway_config"/>
             <argument type="service" id="sylius_mollie.converter.int_to_string"/>
-            <argument type="service" id="sylius.assigner.order_token.unique_id_based"/>
         </service>
 
         <service id="sylius_mollie.controller.shop.credit_card_translation" class="Sylius\MolliePlugin\Controller\Shop\CreditCardTranslationController">

--- a/src/Controller/Shop/PageRedirectController.php
+++ b/src/Controller/Shop/PageRedirectController.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace Sylius\MolliePlugin\Controller\Shop;
 
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Order\Context\CartContextInterface;
-use Sylius\Component\Order\Repository\OrderRepositoryInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -28,7 +27,6 @@ class PageRedirectController
     public function __construct(
         private readonly RouterInterface $router,
         private readonly OrderRepositoryInterface $orderRepository,
-        private readonly CartContextInterface $cartContext,
     ) {
     }
 

--- a/src/Controller/Shop/PageRedirectController.php
+++ b/src/Controller/Shop/PageRedirectController.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace Sylius\MolliePlugin\Controller\Shop;
 
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Order\Context\CartContextInterface;
+use Sylius\Component\Order\Repository\OrderRepositoryInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\RouterInterface;
 
 class PageRedirectController
@@ -28,34 +28,30 @@ class PageRedirectController
     public function __construct(
         private readonly RouterInterface $router,
         private readonly OrderRepositoryInterface $orderRepository,
+        private readonly CartContextInterface $cartContext,
     ) {
     }
 
     public function thankYouAction(Request $request, SessionInterface $session): RedirectResponse
     {
-        $orderToken = $request->get('orderToken');
+        $orderId = $request->get('orderId');
+
+        if (null !== $orderId && (string) $session->get('sylius_mollie_qr_order_id') !== (string) $orderId) {
+            return new RedirectResponse($this->router->generate('sylius_shop_cart_summary'));
+        }
+
+        $session->set('sylius_order_id', $orderId);
         $thankYouPageUrl = $this->router->generate('sylius_shop_order_thank_you');
 
-        if (null === $orderToken || '' === $orderToken) {
-            throw new NotFoundHttpException('Order token is required.');
-        }
-
         /** @var OrderInterface|null $order */
-        $order = $this->orderRepository->findOneByTokenValue($orderToken);
-
-        if (null === $order) {
-            throw new NotFoundHttpException(sprintf('Order with token "%s" does not exist.', $orderToken));
-        }
-
-        $session->set('sylius_order_id', $order->getId());
+        $order = $this->orderRepository->findOneBy(['id' => $orderId]);
         $payment = $order->getLastPayment();
-        $tokenValue = $order->getTokenValue();
+        $orderToken = $order->getTokenValue();
 
         if ($payment?->getState() === self::ORDER_COMPLETED_STATE) {
             return new RedirectResponse($thankYouPageUrl);
         }
-
-        $cartSummaryUrl = $this->router->generate('sylius_shop_order_show', ['tokenValue' => $tokenValue]);
+        $cartSummaryUrl = $this->router->generate('sylius_shop_order_show', ['tokenValue' => $orderToken]);
 
         return new RedirectResponse($cartSummaryUrl);
     }

--- a/src/Controller/Shop/QrCodeAction.php
+++ b/src/Controller/Shop/QrCodeAction.php
@@ -15,7 +15,6 @@ namespace Sylius\MolliePlugin\Controller\Shop;
 
 use Mollie\Api\Resources\Payment;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\Component\Core\TokenAssigner\OrderTokenAssignerInterface;
 use Sylius\Component\Order\Context\CartContextInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\MolliePlugin\Client\MollieApiClient;
@@ -29,6 +28,7 @@ use Sylius\MolliePlugin\Model\DTO\MolliePayment\Metadata;
 use Sylius\MolliePlugin\Model\DTO\MolliePayment\MolliePayment;
 use Sylius\MolliePlugin\Resolver\MollieApiClientKeyResolverInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -44,7 +44,6 @@ final class QrCodeAction
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly RepositoryInterface $methodRepository,
         private readonly IntToStringConverterInterface $intToStringConverter,
-        private readonly OrderTokenAssignerInterface $orderTokenAssigner,
     ) {
     }
 
@@ -57,7 +56,7 @@ final class QrCodeAction
         if ($qrCodeEnabled) {
             /** @var OrderInterface $order */
             $order = $this->cartContext->getCart();
-            $this->orderTokenAssigner->assignTokenValueIfNotSet($order);
+            $request->getSession()->set('sylius_mollie_qr_order_id', $order->getId());
             $molliePayment = $this->buildPaymentObject($request, $order);
 
             try {
@@ -81,19 +80,26 @@ final class QrCodeAction
 
     public function fetchQrCodeFromOrder(Request $request): JsonResponse
     {
-        /** @var OrderInterface|null $order */
-        $order = $this->cartContext->getCart();
-        $orderToken = $request->get('orderToken');
+        $session = $request->getSession();
+        $qrCode = null;
+        $orderId = $request->get('orderId');
 
-        if (null !== $orderToken && '' !== $orderToken &&
-            (null === $order || $order->getTokenValue() !== $orderToken)) {
-            return new JsonResponse([], Response::HTTP_FORBIDDEN);
+        if (null !== $orderId) {
+            if ((string) $session->get('sylius_mollie_qr_order_id') !== (string) $orderId) {
+                return new JsonResponse([], Response::HTTP_FORBIDDEN);
+            }
+
+            $order = $this->orderRepository->findOneBy(['id' => $orderId]);
+        } else {
+            $order = $this->cartContext->getCart();
+            $session->set('sylius_mollie_qr_order_id', $order->getId());
         }
 
-        return new JsonResponse(
-            ['qrCode' => $order?->getQrCode(), 'orderToken' => $order?->getTokenValue()],
-            Response::HTTP_OK,
-        );
+        if (null !== $order) {
+            $qrCode = $order->getQrCode();
+        }
+
+        return new JsonResponse(['qrCode' => $qrCode, 'orderId' => $order->getId()], Response::HTTP_OK);
     }
 
     public function removeQrCodeFromOrder(Request $request): JsonResponse

--- a/src/Controller/Shop/QrCodeAction.php
+++ b/src/Controller/Shop/QrCodeAction.php
@@ -28,7 +28,6 @@ use Sylius\MolliePlugin\Model\DTO\MolliePayment\Metadata;
 use Sylius\MolliePlugin\Model\DTO\MolliePayment\MolliePayment;
 use Sylius\MolliePlugin\Resolver\MollieApiClientKeyResolverInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;

--- a/src/Controller/Shop/QrCodeAction.php
+++ b/src/Controller/Shop/QrCodeAction.php
@@ -15,6 +15,7 @@ namespace Sylius\MolliePlugin\Controller\Shop;
 
 use Mollie\Api\Resources\Payment;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Core\TokenAssigner\OrderTokenAssignerInterface;
 use Sylius\Component\Order\Context\CartContextInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\MolliePlugin\Client\MollieApiClient;
@@ -43,6 +44,7 @@ final class QrCodeAction
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly RepositoryInterface $methodRepository,
         private readonly IntToStringConverterInterface $intToStringConverter,
+        private readonly OrderTokenAssignerInterface $orderTokenAssigner,
     ) {
     }
 
@@ -55,6 +57,7 @@ final class QrCodeAction
         if ($qrCodeEnabled) {
             /** @var OrderInterface $order */
             $order = $this->cartContext->getCart();
+            $this->orderTokenAssigner->assignTokenValueIfNotSet($order);
             $molliePayment = $this->buildPaymentObject($request, $order);
 
             try {

--- a/src/Controller/Shop/QrCodeAction.php
+++ b/src/Controller/Shop/QrCodeAction.php
@@ -88,8 +88,10 @@ final class QrCodeAction
                 return new JsonResponse([], Response::HTTP_FORBIDDEN);
             }
 
+            /** @var OrderInterface|null $order */
             $order = $this->orderRepository->findOneBy(['id' => $orderId]);
         } else {
+            /** @var OrderInterface|null $order */
             $order = $this->cartContext->getCart();
             $session->set('sylius_mollie_qr_order_id', $order->getId());
         }


### PR DESCRIPTION
On the checkout complete page the QR code popup wasn't showing at all — a guard added during the Sylius 1 → 2 migration bailed out early when the select-payment container was missing, so the popup never ran there. Once that was fixed the popup showed briefly but then redirected to an error page, because the order had no orderToken yet during checkout, so the redirect went to /thank-you?orderToken=null → "Order with token null does not exist". 

Fix: run the popup on the complete page regardless of the guard, and assign the order token when the QR payment is created so the flow has a valid token to poll and redirect with.