### PR TITLE
Strip Mollie payment detail keys in other payment methods

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -1,3 +1,21 @@
+# UPGRADE FROM 3.3.3 TO 3.3.4
+
+1. The checkout payment form no longer persists Mollie-specific keys (`molliePaymentMethods`,
+   `cartToken`, `saveCardInfo`, `useSavedCards`) in `Payment::details` for payments made through
+   non-Mollie gateways. When the selected payment method does not use a Mollie gateway, these keys
+   are stripped from the payment details on form submission, so unrelated gateways keep only their
+   own data.
+
+   `Sylius\MolliePlugin\Form\Extension\PaymentTypeExtension` gained an optional
+   `Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface` constructor argument
+   (it falls back to the default checker when omitted), so no changes are required for existing
+   instantiations. Omitting the argument now triggers a deprecation and will be required in 4.0 -
+   if you instantiate the extension yourself, start passing the checker.
+
+# UPGRADE FROM 3.3.2 TO 3.3.3
+
+1. Establish gateway ownership before reading its config in surcharge processor
+
 # UPGRADE FROM 3.3.1 TO 3.3.2
 
 1. Run `yarn install` and `yarn build` to rebuild the shop assets. The bundled

--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -6,11 +6,8 @@
    are stripped from the payment details on form submission, so unrelated gateways keep only their
    own data.
 
-   `Sylius\MolliePlugin\Form\Extension\PaymentTypeExtension` gained an optional
-   `Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface` constructor argument
-   (it falls back to the default checker when omitted), so no changes are required for existing
-   instantiations. Omitting the argument now triggers a deprecation and will be required in 4.0 -
-   if you instantiate the extension yourself, start passing the checker.
+   `Sylius\MolliePlugin\Form\Extension\PaymentTypeExtension` gained a
+   `Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface` constructor argument.
 
 # UPGRADE FROM 3.3.2 TO 3.3.3
 

--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -6,8 +6,11 @@
    are stripped from the payment details on form submission, so unrelated gateways keep only their
    own data.
 
-   `Sylius\MolliePlugin\Form\Extension\PaymentTypeExtension` gained a
-   `Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface` constructor argument.
+   `Sylius\MolliePlugin\Form\Extension\PaymentTypeExtension` gained an optional
+   `Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface` constructor argument
+   (it falls back to the default checker when omitted), so no changes are required for existing
+   instantiations. Omitting the argument now triggers a deprecation and it will be required in 4.0 -
+   if you instantiate the extension yourself, start passing the checker.
 
 # UPGRADE FROM 3.3.2 TO 3.3.3
 

--- a/config/services/form/extension.xml
+++ b/config/services/form/extension.xml
@@ -23,6 +23,7 @@
         </service>
 
         <service id="sylius_mollie.form.extension.type.payment" class="Sylius\MolliePlugin\Form\Extension\PaymentTypeExtension">
+            <argument type="service" id="Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface"/>
             <tag name="form.type_extension" extended_type="Sylius\Bundle\CoreBundle\Form\Type\Checkout\PaymentType"/>
         </service>
 

--- a/src/Form/Extension/PaymentTypeExtension.php
+++ b/src/Form/Extension/PaymentTypeExtension.php
@@ -17,7 +17,6 @@ use Payum\Core\Model\GatewayConfigInterface;
 use Sylius\Bundle\CoreBundle\Form\Type\Checkout\PaymentType;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\MolliePlugin\Form\Type\PaymentMollieType;
-use Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryChecker;
 use Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -27,22 +26,9 @@ use Symfony\Component\Validator\Constraints\Valid;
 
 final class PaymentTypeExtension extends AbstractTypeExtension
 {
-    private readonly MollieGatewayFactoryCheckerInterface $mollieGatewayFactoryChecker;
-
     public function __construct(
-        ?MollieGatewayFactoryCheckerInterface $mollieGatewayFactoryChecker = null,
+        private readonly MollieGatewayFactoryCheckerInterface $mollieGatewayFactoryChecker,
     ) {
-        if (null === $mollieGatewayFactoryChecker) {
-            trigger_deprecation(
-                'sylius/mollie-plugin',
-                '3.3.4',
-                'Not passing a "%s" to "%s" is deprecated and will be required in 4.0.',
-                MollieGatewayFactoryCheckerInterface::class,
-                self::class,
-            );
-        }
-
-        $this->mollieGatewayFactoryChecker = $mollieGatewayFactoryChecker ?? new MollieGatewayFactoryChecker();
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/src/Form/Extension/PaymentTypeExtension.php
+++ b/src/Form/Extension/PaymentTypeExtension.php
@@ -17,6 +17,7 @@ use Payum\Core\Model\GatewayConfigInterface;
 use Sylius\Bundle\CoreBundle\Form\Type\Checkout\PaymentType;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\MolliePlugin\Form\Type\PaymentMollieType;
+use Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryChecker;
 use Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -26,9 +27,22 @@ use Symfony\Component\Validator\Constraints\Valid;
 
 final class PaymentTypeExtension extends AbstractTypeExtension
 {
+    private readonly MollieGatewayFactoryCheckerInterface $mollieGatewayFactoryChecker;
+
     public function __construct(
-        private readonly MollieGatewayFactoryCheckerInterface $mollieGatewayFactoryChecker,
+        ?MollieGatewayFactoryCheckerInterface $mollieGatewayFactoryChecker = null,
     ) {
+        if (null === $mollieGatewayFactoryChecker) {
+            trigger_deprecation(
+                'sylius/mollie-plugin',
+                '3.3.4',
+                'Not passing a "%s" to "%s" is deprecated and will be required in 4.0.',
+                MollieGatewayFactoryCheckerInterface::class,
+                self::class,
+            );
+        }
+
+        $this->mollieGatewayFactoryChecker = $mollieGatewayFactoryChecker ?? new MollieGatewayFactoryChecker();
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/src/Form/Extension/PaymentTypeExtension.php
+++ b/src/Form/Extension/PaymentTypeExtension.php
@@ -13,14 +13,38 @@ declare(strict_types=1);
 
 namespace Sylius\MolliePlugin\Form\Extension;
 
+use Payum\Core\Model\GatewayConfigInterface;
 use Sylius\Bundle\CoreBundle\Form\Type\Checkout\PaymentType;
+use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\MolliePlugin\Form\Type\PaymentMollieType;
+use Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryChecker;
+use Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Validator\Constraints\Valid;
 
 final class PaymentTypeExtension extends AbstractTypeExtension
 {
+    private readonly MollieGatewayFactoryCheckerInterface $mollieGatewayFactoryChecker;
+
+    public function __construct(
+        ?MollieGatewayFactoryCheckerInterface $mollieGatewayFactoryChecker = null,
+    ) {
+        if (null === $mollieGatewayFactoryChecker) {
+            trigger_deprecation(
+                'sylius/mollie-plugin',
+                '3.3.4',
+                'Not passing a "%s" to "%s" is deprecated and will be required in 4.0.',
+                MollieGatewayFactoryCheckerInterface::class,
+                self::class,
+            );
+        }
+
+        $this->mollieGatewayFactoryChecker = $mollieGatewayFactoryChecker ?? new MollieGatewayFactoryChecker();
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -30,10 +54,30 @@ final class PaymentTypeExtension extends AbstractTypeExtension
                     new Valid(),
                 ],
             ]);
+
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event): void {
+            $payment = $event->getData();
+
+            if (!$payment instanceof PaymentInterface || $this->isMolliePayment($payment)) {
+                return;
+            }
+
+            $details = array_diff_key($payment->getDetails(), array_flip(PaymentMollieType::FIELDS));
+
+            $payment->setDetails($details);
+        });
     }
 
     public static function getExtendedTypes(): array
     {
         return [PaymentType::class];
+    }
+
+    private function isMolliePayment(PaymentInterface $payment): bool
+    {
+        /** @var GatewayConfigInterface|null $gatewayConfig */
+        $gatewayConfig = $payment->getMethod()?->getGatewayConfig();
+
+        return null !== $gatewayConfig && $this->mollieGatewayFactoryChecker->isMollieGateway($gatewayConfig);
     }
 }

--- a/src/Form/Type/PaymentMollieType.php
+++ b/src/Form/Type/PaymentMollieType.php
@@ -22,6 +22,22 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class PaymentMollieType extends AbstractType
 {
+    public const FIELD_PAYMENT_METHODS = 'molliePaymentMethods';
+
+    public const FIELD_CART_TOKEN = 'cartToken';
+
+    public const FIELD_SAVE_CARD_INFO = 'saveCardInfo';
+
+    public const FIELD_USE_SAVED_CARDS = 'useSavedCards';
+
+    /** @var array<string> */
+    public const FIELDS = [
+        self::FIELD_PAYMENT_METHODS,
+        self::FIELD_CART_TOKEN,
+        self::FIELD_SAVE_CARD_INFO,
+        self::FIELD_USE_SAVED_CARDS,
+    ];
+
     public function __construct(private readonly MolliePaymentsMethodResolverInterface $methodResolver)
     {
     }
@@ -35,7 +51,7 @@ final class PaymentMollieType extends AbstractType
         $paymentFee = $methods['paymentFee'];
 
         $builder
-            ->add('molliePaymentMethods', ChoiceType::class, [
+            ->add(self::FIELD_PAYMENT_METHODS, ChoiceType::class, [
                 'constraints' => [
                     new PaymentMethodCheckout([
                         'groups' => ['sylius'],
@@ -48,8 +64,8 @@ final class PaymentMollieType extends AbstractType
                     'paymentFee' => $paymentFee[$value],
                 ],
             ])
-            ->add('cartToken', HiddenType::class)
-            ->add('saveCardInfo', HiddenType::class)
-            ->add('useSavedCards', HiddenType::class);
+            ->add(self::FIELD_CART_TOKEN, HiddenType::class)
+            ->add(self::FIELD_SAVE_CARD_INFO, HiddenType::class)
+            ->add(self::FIELD_USE_SAVED_CARDS, HiddenType::class);
     }
 }

--- a/tests/Unit/Form/Extension/PaymentTypeExtensionTest.php
+++ b/tests/Unit/Form/Extension/PaymentTypeExtensionTest.php
@@ -27,7 +27,6 @@ use Sylius\MolliePlugin\Payum\Factory\MollieSubscriptionGatewayFactory;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\FormInterface;
 
 final class PaymentTypeExtensionTest extends TestCase
@@ -45,7 +44,6 @@ final class PaymentTypeExtensionTest extends TestCase
 
     public function testItExtendsTheCheckoutPaymentType(): void
     {
-        $this->assertInstanceOf(FormExtensionInterface::class, $this->extension);
         $this->assertSame([PaymentType::class], PaymentTypeExtension::getExtendedTypes());
     }
 
@@ -114,9 +112,10 @@ final class PaymentTypeExtensionTest extends TestCase
 
     public function testItDoesNothingWhenTheDataIsNotAPayment(): void
     {
-        $this->expectNotToPerformAssertions();
-
         $this->dispatchPostSubmit(new \stdClass());
+
+        // Reaching this point without an exception proves the listener ignored non-payment data.
+        $this->addToAssertionCount(1);
     }
 
     /**

--- a/tests/Unit/Form/Extension/PaymentTypeExtensionTest.php
+++ b/tests/Unit/Form/Extension/PaymentTypeExtensionTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * This file is part of the Sylius Mollie Plugin package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\MolliePlugin\Unit\Form\Extension;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\CoreBundle\Form\Type\Checkout\PaymentType;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\MolliePlugin\Entity\GatewayConfigInterface;
+use Sylius\MolliePlugin\Form\Extension\PaymentTypeExtension;
+use Sylius\MolliePlugin\Form\Type\PaymentMollieType;
+use Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryChecker;
+use Sylius\MolliePlugin\Payum\Factory\MollieGatewayFactory;
+use Sylius\MolliePlugin\Payum\Factory\MollieSubscriptionGatewayFactory;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormExtensionInterface;
+use Symfony\Component\Form\FormInterface;
+
+final class PaymentTypeExtensionTest extends TestCase
+{
+    /** @var array<string, null> */
+    private array $mollieDetails;
+
+    private PaymentTypeExtension $extension;
+
+    protected function setUp(): void
+    {
+        $this->mollieDetails = array_fill_keys(PaymentMollieType::FIELDS, null);
+        $this->extension = new PaymentTypeExtension(new MollieGatewayFactoryChecker());
+    }
+
+    public function testItExtendsTheCheckoutPaymentType(): void
+    {
+        $this->assertInstanceOf(FormExtensionInterface::class, $this->extension);
+        $this->assertSame([PaymentType::class], PaymentTypeExtension::getExtendedTypes());
+    }
+
+    public function testItStripsMollieDetailsFromPaymentsUsingUnrelatedGateways(): void
+    {
+        $payment = $this->createPayment(
+            factoryName: 'offline',
+            details: $this->mollieDetails + ['unrelatedGatewayKey' => 'value'],
+        );
+
+        $payment->expects($this->once())
+            ->method('setDetails')
+            ->with(['unrelatedGatewayKey' => 'value']);
+
+        $this->dispatchPostSubmit($payment);
+    }
+
+    public function testItKeepsMollieDetailsForMolliePayments(): void
+    {
+        $payment = $this->createPayment(
+            factoryName: MollieGatewayFactory::FACTORY_NAME,
+            details: $this->mollieDetails,
+        );
+
+        $payment->expects($this->never())->method('setDetails');
+
+        $this->dispatchPostSubmit($payment);
+    }
+
+    public function testItKeepsMollieDetailsForMollieSubscriptionPayments(): void
+    {
+        $payment = $this->createPayment(
+            factoryName: MollieSubscriptionGatewayFactory::FACTORY_NAME,
+            details: $this->mollieDetails,
+        );
+
+        $payment->expects($this->never())->method('setDetails');
+
+        $this->dispatchPostSubmit($payment);
+    }
+
+    public function testItStripsMollieDetailsWhenPaymentHasNoMethod(): void
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getMethod')->willReturn(null);
+        $payment->method('getDetails')->willReturn($this->mollieDetails);
+
+        $payment->expects($this->once())->method('setDetails')->with([]);
+
+        $this->dispatchPostSubmit($payment);
+    }
+
+    public function testItStripsMollieDetailsWhenPaymentMethodHasNoGatewayConfig(): void
+    {
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $paymentMethod->method('getGatewayConfig')->willReturn(null);
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getMethod')->willReturn($paymentMethod);
+        $payment->method('getDetails')->willReturn($this->mollieDetails);
+
+        $payment->expects($this->once())->method('setDetails')->with([]);
+
+        $this->dispatchPostSubmit($payment);
+    }
+
+    public function testItDoesNothingWhenTheDataIsNotAPayment(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->dispatchPostSubmit(new \stdClass());
+    }
+
+    /**
+     * @return PaymentInterface&MockObject
+     */
+    private function createPayment(string $factoryName, array $details): PaymentInterface
+    {
+        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
+        $gatewayConfig->method('getFactoryName')->willReturn($factoryName);
+
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $paymentMethod->method('getGatewayConfig')->willReturn($gatewayConfig);
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getMethod')->willReturn($paymentMethod);
+        $payment->method('getDetails')->willReturn($details);
+
+        return $payment;
+    }
+
+    private function dispatchPostSubmit(mixed $data): void
+    {
+        $listener = $this->capturePostSubmitListener();
+
+        $listener(new FormEvent($this->createMock(FormInterface::class), $data));
+    }
+
+    private function capturePostSubmitListener(): callable
+    {
+        $listener = null;
+
+        $builder = $this->createMock(FormBuilderInterface::class);
+        $builder->method('add')->willReturnSelf();
+        $builder->method('addEventListener')
+            ->willReturnCallback(function (string $eventName, callable $callback) use (&$listener, $builder): FormBuilderInterface {
+                if (FormEvents::POST_SUBMIT === $eventName) {
+                    $listener = $callback;
+                }
+
+                return $builder;
+            });
+
+        $this->extension->buildForm($builder, []);
+
+        $this->assertNotNull($listener, 'Expected a POST_SUBMIT listener to be registered.');
+
+        return $listener;
+    }
+}

--- a/tests/Unit/Form/Extension/PaymentTypeExtensionTest.php
+++ b/tests/Unit/Form/Extension/PaymentTypeExtensionTest.php
@@ -119,6 +119,25 @@ final class PaymentTypeExtensionTest extends TestCase
     }
 
     /**
+     * @group legacy
+     */
+    public function testItFallsBackToTheDefaultCheckerWhenNoneIsProvided(): void
+    {
+        $extension = new PaymentTypeExtension();
+
+        $payment = $this->createPayment(
+            factoryName: 'offline',
+            details: $this->mollieDetails + ['unrelatedGatewayKey' => 'value'],
+        );
+
+        $payment->expects($this->once())
+            ->method('setDetails')
+            ->with(['unrelatedGatewayKey' => 'value']);
+
+        $this->dispatchPostSubmit($payment, $extension);
+    }
+
+    /**
      * @return PaymentInterface&MockObject
      */
     private function createPayment(string $factoryName, array $details): PaymentInterface
@@ -136,14 +155,14 @@ final class PaymentTypeExtensionTest extends TestCase
         return $payment;
     }
 
-    private function dispatchPostSubmit(mixed $data): void
+    private function dispatchPostSubmit(mixed $data, ?PaymentTypeExtension $extension = null): void
     {
-        $listener = $this->capturePostSubmitListener();
+        $listener = $this->capturePostSubmitListener($extension ?? $this->extension);
 
         $listener(new FormEvent($this->createMock(FormInterface::class), $data));
     }
 
-    private function capturePostSubmitListener(): callable
+    private function capturePostSubmitListener(PaymentTypeExtension $extension): callable
     {
         $listener = null;
 
@@ -158,7 +177,7 @@ final class PaymentTypeExtensionTest extends TestCase
                 return $builder;
             });
 
-        $this->extension->buildForm($builder, []);
+        $extension->buildForm($builder, []);
 
         $this->assertNotNull($listener, 'Expected a POST_SUBMIT listener to be registered.');
 


### PR DESCRIPTION
Relates to https://github.com/Sylius/MolliePlugin/issues/365

The checkout payment form no longer persists Mollie-specific keys (`molliePaymentMethods`, `cartToken`, `saveCardInfo`, `useSavedCards`) in `Payment::details` for payments made through non-Mollie gateways. When the selected payment method does not use a Mollie gateway, these keys are stripped from the payment details on form submission, so unrelated gateways keep only their own data.

`Sylius\MolliePlugin\Form\Extension\PaymentTypeExtension` gained a `Sylius\MolliePlugin\Payum\Checker\MollieGatewayFactoryCheckerInterface` constructor argument.
